### PR TITLE
Reconfigure .eslintignore and run lint-fix and do manual fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,2 @@
-# Proposal Realms
-/proposal-realms
-
-/dist/ses-shim.js
-/dist/ses-shim.js.map
-/src/stringifiedBundle
-/src/old/
-/demo/
-/scripts/
+/dist
+/src/bundles/

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -1,4 +1,3 @@
-/* global Vow */
 // Copyright (C) 2011 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,10 +20,6 @@
 import harden from '@agoric/harden';
 
 export default function setup(syscall, helpers) {
-  function log(what) {
-    helpers.log(what);
-    console.log(what);
-  }
   const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
     syscall,
     helpers.vatID,

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -25,7 +25,10 @@ export default function setup(syscall, helpers) {
     helpers.log(what);
     console.log(what);
   }
-  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
+  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
 
   function mintTest(mint) {
     console.log('starting mintTest');
@@ -106,28 +109,32 @@ export default function setup(syscall, helpers) {
     const bobP = E(bob).init(bobMoneyPurseP, bobStockPurseP);
 
     if (bobLies) {
-      E(bobP).tradeWell(aliceP, true).then(
-        res => {
-          console.log('++ bobP.tradeWell done:', res);
-        },
-        rej => {
-          if (rej.message.startsWith('unexpected contract')) {
-            console.log('++ DONE');
-          } else {
-            console.log('++ bobP.tradeWell error:', rej);
-          }
-        },
-      );
+      E(bobP)
+        .tradeWell(aliceP, true)
+        .then(
+          res => {
+            console.log('++ bobP.tradeWell done:', res);
+          },
+          rej => {
+            if (rej.message.startsWith('unexpected contract')) {
+              console.log('++ DONE');
+            } else {
+              console.log('++ bobP.tradeWell error:', rej);
+            }
+          },
+        );
     } else {
-      E(bobP).tradeWell(aliceP, false).then(
-        res => {
-          console.log('++ bobP.tradeWell done:', res);
-          console.log('++ DONE');
-        },
-        rej => {
-          console.log('++ bobP.tradeWell error:', rej);
-        },
-      );
+      E(bobP)
+        .tradeWell(aliceP, false)
+        .then(
+          res => {
+            console.log('++ bobP.tradeWell done:', res);
+            console.log('++ DONE');
+          },
+          rej => {
+            console.log('++ bobP.tradeWell error:', rej);
+          },
+        );
     }
     //  return E(aliceP).tradeWell(bobP);
   }

--- a/demo/contractHost/escrow.js
+++ b/demo/contractHost/escrow.js
@@ -1,6 +1,7 @@
-/* global console require E */
+/* global require E */
 
 export default function escrowExchange(a, b) {
+  /* eslint-disable-next-line global-require */
   const harden = require('@agoric/harden');
 
   function join(xP, yP) {

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -23,6 +23,7 @@ function makeAlice(E, host) {
   let initialized = false;
   let myMoneyPurseP;
   let myMoneyIssuerP;
+  /* eslint-disable-next-line no-unused-vars */
   let myStockPurseP;
   let myStockIssuerP;
 

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -106,11 +106,16 @@ function makeAlice(E, host) {
 }
 
 export default function setup(syscall, helpers) {
-  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
-  registerRoot(harden({
-    makeAlice(host) {
-      return harden(makeAlice(E, host));
-    },
-  }));
+  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
+  registerRoot(
+    harden({
+      makeAlice(host) {
+        return harden(makeAlice(E, host));
+      },
+    }),
+  );
   return dispatch;
 }

--- a/demo/contractHost/vat-bob.js
+++ b/demo/contractHost/vat-bob.js
@@ -70,7 +70,9 @@ function makeBob(E, host) {
         }
       }
 
-      return E(myMoneyPurseP).deposit(10, paymentP).then(_ => good);
+      return E(myMoneyPurseP)
+        .deposit(10, paymentP)
+        .then(_ => good);
     },
 
     tradeWell(alice, bobLies = false) {
@@ -137,11 +139,16 @@ function makeBob(E, host) {
 }
 
 export default function setup(syscall, helpers) {
-  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
-  registerRoot(harden({
-    makeBob(host) {
-      return harden(makeBob(E, host));
-    },
-  }));
+  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
+  registerRoot(
+    harden({
+      makeBob(host) {
+        return harden(makeBob(E, host));
+      },
+    }),
+  );
   return dispatch;
 }

--- a/demo/contractHost/vat-bob.js
+++ b/demo/contractHost/vat-bob.js
@@ -1,4 +1,3 @@
-/* global Vow Flow */
 // Copyright (C) 2013 Google Inc.
 // Copyright (C) 2018 Agoric
 //

--- a/demo/contractHost/vat-host.js
+++ b/demo/contractHost/vat-host.js
@@ -82,8 +82,8 @@
 
 /* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
 import harden from '@agoric/harden';
-import makePromise from '../../src/kernel/makePromise';
 import evaluate from '@agoric/evaluate';
+import makePromise from '../../src/kernel/makePromise';
 
 function makeHost(E) {
   const m = new WeakMap();
@@ -94,22 +94,22 @@ function makeHost(E) {
       const tokens = [];
       const argPs = [];
       const { p: resultP, res: resolve } = makePromise();
-      //let resolve;
-      //const f = new Flow();
-      //const resultP = f.makeVow(r => (resolve = r));
+      // let resolve;
+      // const f = new Flow();
+      // const resultP = f.makeVow(r => (resolve = r));
       const contract = evaluate(contractSrc, {
-        //Flow,
-        //Vow,
+        // Flow,
+        // Vow,
         console,
         require,
         E,
       });
-      //console.log(`confined contract is ${typeof contract} ${contract}`);
+      // console.log(`confined contract is ${typeof contract} ${contract}`);
 
       const addParam = (i, token) => {
         tokens[i] = token;
-        //let resolveArg;
-        //argPs[i] = f.makeVow(r => (resolveArg = r));
+        // let resolveArg;
+        // argPs[i] = f.makeVow(r => (resolveArg = r));
         const p = makePromise();
         const resolveArg = p.res;
         argPs[i] = p.p;
@@ -144,11 +144,16 @@ function makeHost(E) {
 }
 
 export default function setup(syscall, helpers) {
-  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
-  registerRoot(harden({
-    makeHost() {
-      return harden(makeHost(E));
-    },
-  }));
+  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
+  registerRoot(
+    harden({
+      makeHost() {
+        return harden(makeHost(E));
+      },
+    }),
+  );
   return dispatch;
 }

--- a/demo/contractHost/vat-mint.js
+++ b/demo/contractHost/vat-mint.js
@@ -82,7 +82,10 @@ function build(E) {
 }
 
 export default function setup(syscall, helpers) {
-  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
+  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
   const obj0 = build(E);
   registerRoot(harden(obj0));
   return dispatch;

--- a/demo/contractHost/vat-mint.js
+++ b/demo/contractHost/vat-mint.js
@@ -16,7 +16,7 @@
 import Nat from '@agoric/nat';
 import harden from '@agoric/harden';
 
-function build(E) {
+function build(_E) {
   let debugCounter = 0;
 
   function makeMint() {

--- a/demo/left-right/bootstrap.js
+++ b/demo/left-right/bootstrap.js
@@ -8,7 +8,10 @@ export default function setup(syscall, helpers) {
     console.log(what);
   }
   log(`bootstrap called`);
-  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
+  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
   const obj0 = {
     bootstrap(argv, vats) {
       E(vats.left)

--- a/demo/left-right/vat-left.js
+++ b/demo/left-right/vat-left.js
@@ -5,7 +5,10 @@ export default function setup(syscall, helpers) {
     helpers.log(what);
     console.log(what);
   }
-  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
+  const { E, dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
 
   const t1 = {
     callRight(arg1, right) {

--- a/demo/left-right/vat-right.js
+++ b/demo/left-right/vat-right.js
@@ -5,7 +5,10 @@ export default function setup(syscall, helpers) {
     helpers.log(what);
     console.log(what);
   }
-  const { dispatch, registerRoot } = helpers.makeLiveSlots(syscall, helpers.vatID);
+  const { dispatch, registerRoot } = helpers.makeLiveSlots(
+    syscall,
+    helpers.vatID,
+  );
 
   const obj0 = {
     bar(arg2) {

--- a/scripts/build-kernel.js
+++ b/scripts/build-kernel.js
@@ -11,9 +11,11 @@ async function main() {
   await f.close();
 }
 
-
-main().then(_ => process.exit(0), err => {
-  console.log('error creating src/bundles/kernel:');
-  console.log(err);
-  process.exit(1);
-});
+main().then(
+  _ => process.exit(0),
+  err => {
+    console.log('error creating src/bundles/kernel:');
+    console.log(err);
+    process.exit(1);
+  },
+);

--- a/scripts/build-kernel.js
+++ b/scripts/build-kernel.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import process from 'process';
-import { rollup } from 'rollup';
 import bundleSource from '../src/build-source-bundle';
 
 async function main() {


### PR DESCRIPTION
This PR reconfigures .eslintignore to remove SES-specific settings and add settings relevant to SwingSet. 

It also runs `npm run lint-fix` on the repo.

The last commit is a manual run through of the remaining issues. This probably needs an extra set of eyes to make sure the changes are correct. 

Closes #12