### PR TITLE
Fix #22: Remove domain property from promise

### DIFF
--- a/src/kernel/makePromise.js
+++ b/src/kernel/makePromise.js
@@ -7,5 +7,23 @@ export default function makePromise() {
     res = resolve;
     rej = reject;
   });
+  // Node.js adds the `domain` property which is not a standard
+  // property on Promise. Because we do not know it to be ocap-safe,
+  // we remove it.
+  if (p.domain) {
+    // deleting p.domain may break functionality. To retain current
+    // functionality at the expense of safety, set unsafe to true.
+    const unsafe = false;
+    if (unsafe) {
+      const originalDomain = p.domain;
+      Object.defineProperty(p, 'domain', {
+        get() {
+          return originalDomain;
+        },
+      });
+    } else {
+      delete p.domain;
+    }
+  }
   return harden({ p, res, rej });
 }


### PR DESCRIPTION
This PR (work done by @erights) deletes the `domain` property from any promises being created through `makePromise`. That may break some functionality, so there is also an option called `unsafe` that turns on an alternative. 

Closes #22