### PR TITLE
Add CommsSlots

### DIFF
--- a/bin/vat
+++ b/bin/vat
@@ -5,8 +5,14 @@ const path = require('path');
 const process = require('process');
 const repl = require('repl');
 require = require('esm')(module);
+const util = require('util');
 
+const { buildChannel } = require('../src/devices');
 const { loadBasedir, buildVatController } = require('../src/index.js');
+
+function deepLog(item) {
+  console.log(util.inspect(item, false, null, true));
+}
 
 async function main() {
   let argv = process.argv.splice(2);
@@ -22,8 +28,28 @@ async function main() {
   const basedir = (argv[0] === '--' || argv[0] === undefined) ? '.' : argv.shift();
   const vatArgv = argv[0] === '--' ? argv.slice(1) : argv;
 
+  const channelDevice = buildChannel();
+  const vatDevices = new Map();
+  const commsConfig = {
+    devices: {
+      channel: {
+        attenuatorSource: channelDevice.attenuatorSource,
+        bridge: channelDevice.bridge,
+      },
+    },
+  };
 
   const config = await loadBasedir(basedir);
+  for (const vatID of config.vatSources.keys()) {
+    if (vatID.endsWith('comms')) {
+      vatDevices.set(vatID, commsConfig);
+    }
+  }
+
+  if (vatDevices.size > 0) {
+    config.vatDevices = vatDevices;
+  }
+
   const controller = await buildVatController(config, withSES, vatArgv);
   if (command === 'run') {
     await controller.run();
@@ -35,12 +61,12 @@ async function main() {
     r.context.dump = () => {
       const d = controller.dump();
       console.log('Kernel Table:');
-      console.log(d.kernelTable);
+      deepLog(d.kernelTable);
       console.log('Promises:');
-      console.log(d.promises);
+      deepLog(d.promises);
       console.log('Run Queue:');
-      console.log(d.runQueue);
-    };
+      deepLog(d.runQueue);
+    }; 
     r.context.run = () => {console.log('run!'); controller.run();};
     r.context.step = () => {console.log('step!'); controller.step();};
     r.context.save = () => {
@@ -52,4 +78,3 @@ async function main() {
 }
 
 main();
-

--- a/demo/encouragementBotComms/bootstrap.js
+++ b/demo/encouragementBotComms/bootstrap.js
@@ -1,0 +1,65 @@
+import harden from '@agoric/harden';
+
+console.log(`=> loading bootstrap.js`);
+
+export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+    console.log(what);
+  }
+  log(`=> setup called`);
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E =>
+      harden({
+        async bootstrap(argv, vats) {
+          console.log('=> bootstrap() called');
+
+          const BOT_MACHINE_NAME = 'bot';
+          const USER_MACHINE_NAME = 'user';
+          const BOT_USER_CHANNEL = 'channel';
+          const BOT_CLIST_INDEX = 0;
+
+          await E(vats.botcomms).init(BOT_MACHINE_NAME, 'botSigningKey');
+          await E(vats.usercomms).init(USER_MACHINE_NAME, 'userSigningKey');
+
+          await E(vats.botcomms).connect(
+            USER_MACHINE_NAME,
+            'userVerifyingKey',
+            BOT_USER_CHANNEL,
+          );
+
+          await E(vats.botcomms).addExport(
+            USER_MACHINE_NAME,
+            BOT_CLIST_INDEX,
+            vats.bot,
+          );
+
+          await E(vats.usercomms).connect(
+            BOT_MACHINE_NAME,
+            'botVerifyingKey',
+            BOT_USER_CHANNEL,
+          ); // channel - means of connection -- all three can collapse into libp2p address
+
+          const pPBot = E(vats.usercomms).addImport(
+            BOT_MACHINE_NAME,
+            BOT_CLIST_INDEX,
+          );
+          E(vats.user)
+            .talkToBot(pPBot, 'bot')
+            .then(
+              r =>
+                log(
+                  `=> the promise given by the call to user.talkToBot resolved to '${r}'`,
+                ),
+              err =>
+                log(
+                  `=> the promise given by the call to user.talkToBot was rejected '${err}''`,
+                ),
+            );
+        },
+      }),
+    helpers.vatID,
+  );
+}

--- a/demo/encouragementBotComms/vat-bot.js
+++ b/demo/encouragementBotComms/vat-bot.js
@@ -1,0 +1,21 @@
+import harden from '@agoric/harden';
+
+export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+    console.log(what);
+  }
+
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    _E =>
+      harden({
+        encourageMe(name) {
+          log(`=> encouragementBot.encourageMe got the name: ${name}`);
+          return `${name}, you are awesome, keep it up!`;
+        },
+      }),
+    helpers.vatID,
+  );
+}

--- a/demo/encouragementBotComms/vat-botcomms.js
+++ b/demo/encouragementBotComms/vat-botcomms.js
@@ -1,0 +1,3 @@
+export default function setup(syscall, state, helpers, devices) {
+  return helpers.makeCommsSlots(syscall, state, helpers, devices);
+}

--- a/demo/encouragementBotComms/vat-user.js
+++ b/demo/encouragementBotComms/vat-user.js
@@ -1,0 +1,25 @@
+import harden from '@agoric/harden';
+
+export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+    console.log(what);
+  }
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E =>
+      harden({
+        talkToBot(pbot, botName) {
+          log(`=> user.talkToBot is called with ${botName}`);
+          E(pbot)
+            .encourageMe('user')
+            .then(myEncouragement =>
+              log(`=> user receives the encouragement: ${myEncouragement}`),
+            );
+          return 'Thanks for the setup. I sure hope I get some encouragement...';
+        },
+      }),
+    helpers.vatID,
+  );
+}

--- a/demo/encouragementBotComms/vat-usercomms.js
+++ b/demo/encouragementBotComms/vat-usercomms.js
@@ -1,0 +1,3 @@
+export default function setup(syscall, state, helpers, devices) {
+  return helpers.makeCommsSlots(syscall, state, helpers, devices);
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pack-evaluate": "cd agoric-evaluate && npm pack",
     "pack": "npm run-script build-kernel && npm pack",
     "publish": "npm run-script pack && npm publish --access public",
-    "test": "npm run-script build-kernel && tape -r esm test/test-node-version.js && tape -r esm test/**/test*.js",
+    "test": "npm run-script build-kernel && tape -r esm test/test-node-version.js && tape -r esm test/**/**/**/test*.js",
     "pretty-fix": "prettier --write '**/*.{js,jsx}'",
     "pretty-check": "prettier --check '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pack-evaluate": "cd agoric-evaluate && npm pack",
     "pack": "npm run-script build-kernel && npm pack",
     "publish": "npm run-script pack && npm publish --access public",
-    "test": "npm run-script build-kernel && tape -r esm test/test-node-version.js && tape -r esm test/**/**/**/test*.js",
+    "test": "npm run-script build-kernel && tape -r esm test/test-node-version.js && tape -r esm 'test/**/test*.js'",
     "pretty-fix": "prettier --write '**/*.{js,jsx}'",
     "pretty-check": "prettier --check '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",

--- a/src/controller.js
+++ b/src/controller.js
@@ -45,7 +45,7 @@ export function loadBasedir(basedir, stateArg) {
   } catch (e) {
     state = stateArg;
   }
-  return harden({ vatSources, bootstrapIndexJS, state });
+  return { vatSources, bootstrapIndexJS, state };
 }
 
 function getKernelSource() {
@@ -182,8 +182,17 @@ export async function buildVatController(config, withSES = true, argv = []) {
 
   if (config.vatSources) {
     for (const vatID of config.vatSources.keys()) {
-      // eslint-disable-next-line no-await-in-loop
-      await controller.addVat(vatID, config.vatSources.get(vatID));
+      if (config.vatDevices) {
+        // eslint-disable-next-line no-await-in-loop
+        await controller.addVat(
+          vatID,
+          config.vatSources.get(vatID),
+          config.vatDevices.get(vatID),
+        );
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        await controller.addVat(vatID, config.vatSources.get(vatID));
+      }
     }
   }
 

--- a/src/devices.js
+++ b/src/devices.js
@@ -59,3 +59,36 @@ export function buildInbound() {
     deliverInbound,
   };
 }
+
+export function buildChannel() {
+  const bridge = new Map();
+  // receiverMachineName -> inboundCallback
+
+  function attenuatorSource(e) {
+    // eslint-disable-next-line no-shadow
+    const { bridge } = e;
+    // eslint-disable-next-line global-require
+    const harden = require('@agoric/harden');
+    return harden({
+      registerInboundCallback(myMachineName, f) {
+        bridge.set(myMachineName, f);
+      },
+      sendOverChannel(fromMachineName, toMachineName, data) {
+        const callback = bridge.get(toMachineName);
+        if (!callback) {
+          throw new Error('callback must be defined first');
+        }
+        try {
+          callback(`${fromMachineName}`, `${data}`);
+        } catch (err) {
+          console.log(`error during callback: ${e} ${e.message}`);
+        }
+      },
+    });
+  }
+
+  return {
+    attenuatorSource: `(${attenuatorSource})`,
+    bridge,
+  };
+}

--- a/src/kernel/commsSlots/commsSlots.js
+++ b/src/kernel/commsSlots/commsSlots.js
@@ -49,7 +49,6 @@ export function makeCommsSlots(syscall, _state, helpers, devices) {
       }
       const { args } = JSON.parse(argsbytes);
 
-
       const slots = caps.map(facet => {
         const { key } = state.clists.getMachine('inbound', facet.id);
         return { type: 'export', index: key };
@@ -63,7 +62,6 @@ export function makeCommsSlots(syscall, _state, helpers, devices) {
         slots,
         resultIndex: resolverID,
       });
-
 
       helpers.log(
         `sendOverChannel from ${state.machineState.getMachineName()}, to: ${
@@ -139,7 +137,7 @@ export function makeCommsSlots(syscall, _state, helpers, devices) {
 
     notifyReject(promiseID, data, slots) {
       csdebug(`cs.dispatch.notifyReject(${promiseID}, ${data}, ${slots})`);
-      
+
       // eslint-disable-next-line array-callback-return
       state.subscribers.get(promiseID).map(subscriber => {
         const channel = state.channels.getChannelDevice(subscriber);
@@ -155,7 +153,6 @@ export function makeCommsSlots(syscall, _state, helpers, devices) {
         ); // fromMachineName, toMachineName, data
       });
     },
-  
 
     // for testing purposes only
     getState() {

--- a/src/kernel/commsSlots/commsSlots.js
+++ b/src/kernel/commsSlots/commsSlots.js
@@ -115,6 +115,7 @@ export function makeCommsSlots(syscall, _state, helpers, devices) {
       // we need to get the targetMachine from the promiseID
       // we need to stringify the slot and the promiseID into data.
 
+      // TODO: map the slot
       const data = JSON.stringify({
         event: 'notifyFulfillToTarget',
         promiseID,

--- a/src/kernel/commsSlots/commsSlots.js
+++ b/src/kernel/commsSlots/commsSlots.js
@@ -1,0 +1,167 @@
+import harden from '@agoric/harden';
+
+// state
+import makeState from './state/index';
+
+// bootstrap functions
+import handleBootstrap from './handleBootstrap';
+
+export function makeCommsSlots(syscall, _state, helpers, devices) {
+  const enableCSDebug = false;
+  const { vatID: forVatID } = helpers;
+  function csdebug(...args) {
+    if (enableCSDebug) {
+      console.log(...args);
+    }
+  }
+
+  // setup
+  const state = makeState(forVatID);
+
+  const dispatch = harden({
+    deliver(facetid, method, argsbytes, caps, resolverID) {
+      csdebug(
+        `ls[${forVatID}].dispatch.deliver ${facetid}.${method} -> ${resolverID}`,
+      );
+      csdebug('argsbytes', argsbytes);
+      csdebug('caps', caps);
+
+      // if we are hitting the initial object (0), we are in bootstrap
+      if (facetid === 0) {
+        const result = handleBootstrap(
+          state,
+          syscall,
+          method,
+          argsbytes,
+          caps,
+          resolverID,
+          helpers,
+          devices,
+        );
+        return result;
+      }
+
+      // look up facetid and send a message to the resulting machine
+
+      const machineInfo = state.clists.getMachine('inbound', facetid);
+      if (!machineInfo) {
+        throw new Error('unknown facetid');
+      }
+      const { args } = JSON.parse(argsbytes);
+
+
+      const slots = caps.map(facet => {
+        const { key } = state.clists.getMachine('inbound', facet.id);
+        return { type: 'export', index: key };
+      });
+
+      const channel = state.channels.getChannelDevice(machineInfo.machineName);
+      const message = JSON.stringify({
+        index: machineInfo.key,
+        methodName: method,
+        args,
+        slots,
+        resultIndex: resolverID,
+      });
+
+
+      helpers.log(
+        `sendOverChannel from ${state.machineState.getMachineName()}, to: ${
+          machineInfo.machineName
+        } message: ${message}`,
+      );
+
+      return devices[channel].sendOverChannel(
+        state.machineState.getMachineName(),
+        machineInfo.machineName,
+        message,
+      );
+    },
+
+    notifyFulfillToData(promiseID, data, slots) {
+      csdebug(
+        `cs.dispatch.notifyFulfillToData(${promiseID}, ${data}, ${slots})`,
+      );
+
+      const machineInfo = state.clists.getMachine('outbound', {
+        type: 'promise',
+        id: promiseID,
+      });
+
+      const dataMsg = JSON.stringify({
+        event: 'notifyFulfillToData',
+        resolverID: machineInfo.key,
+        data,
+      });
+
+      // eslint-disable-next-line array-callback-return
+      state.subscribers.get(promiseID).map(subscriber => {
+        const channel = state.channels.getChannelDevice(subscriber);
+
+        helpers.log(
+          `sendOverChannel from ${state.machineState.getMachineName()}, to: ${subscriber}: ${dataMsg}`,
+        );
+
+        devices[channel].sendOverChannel(
+          state.machineState.getMachineName(),
+          subscriber,
+          dataMsg,
+        ); // fromMachineName, toMachineName, data
+      });
+    },
+
+    notifyFulfillToTarget(promiseID, slot) {
+      csdebug(`cs.dispatch.notifyFulfillToTarget(${promiseID}, ${slot})`);
+
+      // we are given the promiseID and the slot.
+      // we need to get the targetMachine from the promiseID
+      // we need to stringify the slot and the promiseID into data.
+
+      const data = JSON.stringify({
+        event: 'notifyFulfillToTarget',
+        promiseID,
+        target: slot,
+      });
+
+      // eslint-disable-next-line array-callback-return
+      state.subscribers.get(promiseID).map(subscriber => {
+        const channel = state.channels.getChannelDevice(subscriber);
+
+        helpers.log(`sendOverChannel message: ${data}`);
+
+        devices[channel].sendOverChannel(
+          state.machineState.getMachineName(),
+          subscriber,
+          data,
+        ); // fromMachineName, toMachineName, data
+      });
+    },
+
+    notifyReject(promiseID, data, slots) {
+      csdebug(`cs.dispatch.notifyReject(${promiseID}, ${data}, ${slots})`);
+      
+      // eslint-disable-next-line array-callback-return
+      state.subscribers.get(promiseID).map(subscriber => {
+        const channel = state.channels.getChannelDevice(subscriber);
+
+        helpers.log(
+          `sendOverChannel notifyReject promiseID: ${promiseID}, data: ${data}`,
+        );
+
+        devices[channel].sendOverChannel(
+          state.machineState.getMachineName(),
+          subscriber,
+          data,
+        ); // fromMachineName, toMachineName, data
+      });
+    },
+  
+
+    // for testing purposes only
+    getState() {
+      return state;
+    },
+  });
+
+  return dispatch;
+}

--- a/src/kernel/commsSlots/handleBootstrap.js
+++ b/src/kernel/commsSlots/handleBootstrap.js
@@ -1,0 +1,105 @@
+// access to the outside world
+import { makeSendIn } from './makeSendIn';
+
+export default function handleBootstrap(
+  state,
+  syscall,
+  method,
+  argsbytes,
+  caps,
+  resolverID,
+  helpers,
+  devices,
+) {
+  function init([name, proofMaterial]) {
+    helpers.log(`init called with name ${name}`);
+    if (
+      state.machineState.getMachineName() != null ||
+      state.machineState.getProofMaterial() != null
+    ) {
+      throw new Error('commsVat has already been initialized');
+    }
+
+    state.machineState.setMachineName(name);
+    state.machineState.setProofMaterial(proofMaterial);
+
+    syscall.fulfillToData(
+      resolverID,
+      JSON.stringify(state.machineState.getMachineName()),
+      [],
+    );
+  }
+
+  function connect([otherMachineName, _verifyingKey, channelName]) {
+    helpers.log(
+      `connect called with otherMachineName ${otherMachineName}, channelName ${channelName}`,
+    );
+    if (channelName !== 'channel') {
+      throw new Error('channel not recognized');
+    }
+
+    // TODO: check signature on this
+    // in the future, data structure would contain name and predicate
+
+    state.channels.add(otherMachineName, channelName);
+    const { sendIn } = makeSendIn(state, syscall);
+
+    if (devices && devices[channelName]) {
+      devices[channelName].registerInboundCallback(
+        state.machineState.getMachineName(),
+        sendIn,
+      );
+    }
+
+    syscall.fulfillToData(resolverID, JSON.stringify('undefined'), []);
+  }
+
+  function addExport([sender, index, valslot]) {
+    helpers.log(`addExport called with sender ${sender}, index ${index}`);
+    if (
+      typeof valslot !== 'object' ||
+      !('@qclass' in valslot) ||
+      valslot['@qclass'] !== 'slot'
+    ) {
+      throw new Error(`value must be a slot, not ${JSON.stringify(valslot)}`);
+    }
+    const val = caps[valslot.index];
+
+    state.clists.add('outbound', sender, index, val);
+    syscall.fulfillToData(resolverID, JSON.stringify('undefined'), []);
+  }
+
+  function addImport([machineName, index]) {
+    helpers.log(
+      `addImport called with machineName ${machineName}, index ${index}`,
+    );
+    // if we have already imported this, return the same id
+    let id = state.clists.getKernelExport('inbound', machineName, index);
+
+    // otherwise, create the id and store it
+    if (id === undefined) {
+      id = state.ids.getNextImportID();
+      state.clists.add('inbound', machineName, index, id);
+    }
+
+    syscall.fulfillToTarget(resolverID, {
+      type: 'export',
+      id,
+    });
+  }
+
+  const { args } = JSON.parse(argsbytes);
+
+  switch (method) {
+    case 'init':
+      return init(args);
+    case 'addExport':
+      return addExport(args);
+    case 'connect':
+      return connect(args);
+    case 'addImport':
+      return addImport(args);
+    default:
+      throw new Error(`method ${method} is not available`);
+  }
+}

--- a/src/kernel/commsSlots/helpers.js
+++ b/src/kernel/commsSlots/helpers.js
@@ -1,0 +1,9 @@
+export function parseJSON(data) {
+  try {
+    const d = JSON.parse(data);
+    return d;
+  } catch (e) {
+    console.log(`unparseable data: ${data}`);
+    throw e;
+  }
+}

--- a/src/kernel/commsSlots/index.js
+++ b/src/kernel/commsSlots/index.js
@@ -1,0 +1,3 @@
+import { makeCommsSlots } from './commsSlots';
+
+export { makeCommsSlots };

--- a/src/kernel/commsSlots/makeSendIn.js
+++ b/src/kernel/commsSlots/makeSendIn.js
@@ -72,7 +72,7 @@ export function makeSendIn(state, syscall) {
         }
 
         function translateSlot(externalSlot) {
-          // isObjectAndTypeIsExport(externalSlot);
+          isObjectAndTypeIsExport(externalSlot);
           return state.clists.getKernelExport(
             'outbound',
             senderID,

--- a/src/kernel/commsSlots/makeSendIn.js
+++ b/src/kernel/commsSlots/makeSendIn.js
@@ -1,0 +1,112 @@
+import { parseJSON } from './helpers';
+
+// TODO: implement verify
+function verify(_senderID) {
+  return true;
+}
+
+export function makeSendIn(state, syscall) {
+  return {
+    /**
+     * aka 'inbound' from SwingSet-Cosmos
+     * @param  {string} senderID public key?
+     * @param  {string} dataStr JSON, such as:
+     * {
+     *  index: 0,
+     *  methodName: 'getIssuer',
+     *  args: [],
+     *  resultIndex: 1,
+     * }
+     *
+     */
+    sendIn(senderID, dataStr) {
+      if (!verify(senderID)) {
+        throw new Error('could not verify SenderID');
+      }
+
+      // "{"index":0,"methodName":"encourageMe","args":["user"],"slots":[],"resultIndex":33}"
+      // "{"event":"notifyFulfillToData","resolverID":33,"data":"\"user, you are awesome, keep it up!\""}"
+
+      const data = parseJSON(dataStr);
+
+      if (data.event === 'notifyFulfillToData') {
+        syscall.fulfillToData(data.resolverID, data.data, []);
+        return;
+      }
+
+      // get the target (an object representing a promise or a vat
+      // object) from the index in the data
+      const targetObject = state.clists.getKernelExport(
+        'outbound',
+        senderID,
+        data.index,
+      );
+
+      /* slots are only in use by ag-cosmos-client.js when referencing a
+        presence as an arg, e.g.:
+        {
+          index: 2,
+          methodName: 'deposit',
+          args: [20, { '@qclass': 'slot', index: 0 }],
+          slots: [{ type: 'export', index: 0 }],
+          resultIndex: 3,
+        }
+      */
+
+      // e.g.: slots: [{ type: 'export', index: 0 }],
+      // translate an external slot description to the commsVat's
+      // perspective?
+      // .e.g { index: 0, type: 'export' } ->  { type: 'import', id: 10 }
+      function translateSlotsArray(slotsArray) {
+        function isObjectAndTypeIsExport(externalSlot) {
+          if (
+            typeof externalSlot !== 'object' ||
+            externalSlot.type !== 'export'
+          ) {
+            throw new Error(
+              `extSlot must currently be type:export, not ${JSON.stringify(
+                externalSlot,
+              )}`,
+            );
+          }
+        }
+
+        function translateSlot(externalSlot) {
+          // isObjectAndTypeIsExport(externalSlot);
+          return state.clists.getKernelExport(
+            'outbound',
+            senderID,
+            externalSlot.index,
+          );
+        }
+        return slotsArray.map(translateSlot);
+      }
+      let slots = [];
+      if (data.slots) {
+        slots = translateSlotsArray(data.slots);
+      }
+
+      // put the target.methodName(args, slots) call on the runQueue to
+      // be delivered
+      const promiseID = syscall.send(
+        targetObject,
+        data.methodName,
+        JSON.stringify({ args: data.args }),
+        slots,
+      );
+
+      // if there is a resultIndex passed in, the inbound sender wants
+      // to know about the result, so we need to store this in clist for
+      // the sender to have future access to
+
+      if (data.resultIndex) {
+        state.clists.add('outbound', senderID, data.resultIndex, {
+          type: 'promise',
+          id: promiseID,
+        });
+        state.subscribers.add(promiseID, senderID);
+        syscall.subscribe(promiseID);
+      }
+    },
+  };
+}

--- a/src/kernel/commsSlots/state/index.js
+++ b/src/kernel/commsSlots/state/index.js
@@ -1,0 +1,37 @@
+import { makeCLists } from './makeCLists';
+import { makeSubscribers } from './makeSubscribers';
+import { makeChannels } from './makeChannels';
+import { makeGetNextImportID } from './makeGetNextImportID';
+import { makeMachineState } from './makeMachineState';
+
+function makeState(name) {
+  const vatName = name;
+  const machineState = makeMachineState();
+  const clists = makeCLists();
+  const subscribers = makeSubscribers();
+  const channels = makeChannels();
+  const ids = makeGetNextImportID();
+
+  function dumpState() {
+    console.log('STATE', {
+      machineState: machineState.dump(),
+      clists: clists.dump(),
+      subscribers: subscribers.dump(),
+      channels: channels.dump(),
+      nextID: ids.dump(),
+      vatName,
+    });
+  }
+
+  return {
+    clists,
+    subscribers,
+    channels,
+    ids,
+    machineState,
+    dumpState,
+    vatName,
+  };
+}
+
+export default makeState;

--- a/src/kernel/commsSlots/state/makeCLists.js
+++ b/src/kernel/commsSlots/state/makeCLists.js
@@ -1,0 +1,59 @@
+/**
+ * MakeCLists Module
+ * This module is instantiated per CommsVat and stores data about
+ * mappings between external machines and slots.
+ *
+ * We need to store the data in two separate groups:
+ *  * inbound to a commsvat means we are getting information about an
+ *    object that lives on another machine.
+ *  * outbound to a commsvat means that we are passing along
+ *    information to an another machine
+ *
+ * a clist maps an index to an object describing a slot
+ * for example, one mapping for promises is:
+ * resultIndex -> { type: 'promise', id: promiseID }
+ *
+ * @module makeCLists
+ */
+
+export function makeCLists() {
+  const state = new Map();
+
+  function createKeyObj(direction, machineName, key) {
+    return {
+      direction,
+      machineName,
+      key,
+    };
+  }
+
+  function createValueObj(direction, value) {
+    return {
+      direction,
+      kernelExport: value,
+    };
+  }
+
+  function getKernelExport(direction, machineName, key) {
+    return state.get(JSON.stringify(createKeyObj(direction, machineName, key)));
+  }
+
+  function getMachine(direction, kernelExport) {
+    return state.get(JSON.stringify(createValueObj(direction, kernelExport)));
+  }
+
+  function add(direction, machineName, key, value) {
+    const keyObj = createKeyObj(direction, machineName, key);
+    state.set(JSON.stringify(keyObj), value);
+    state.set(JSON.stringify(createValueObj(direction, value)), keyObj);
+  }
+
+  return {
+    getKernelExport,
+    getMachine,
+    add,
+    dump() {
+      return state;
+    },
+  };
+}

--- a/src/kernel/commsSlots/state/makeChannels.js
+++ b/src/kernel/commsSlots/state/makeChannels.js
@@ -1,0 +1,30 @@
+// TODO: check signature on this
+// in the future, data structure would contain name and predicate
+
+// this maps machines to deviceNames to be used as a channel
+export function makeChannels() {
+  const machineToChannelDevice = new Map();
+  const channelDeviceToMachine = new Map();
+
+  return {
+    /**
+     * @param  {string} machineName
+     * @param  {string} deviceName
+     */
+    add(machineName, deviceName) {
+      machineToChannelDevice.set(machineName, deviceName);
+      channelDeviceToMachine.set(deviceName, machineName);
+    },
+    /**
+     * Get the callback that reaches the machine
+     * @param  {string} machine
+     * @returns {string} deviceName
+     */
+    getChannelDevice(machine) {
+      return machineToChannelDevice.get(machine);
+    },
+    dump() {
+      return machineToChannelDevice;
+    },
+  };
+}

--- a/src/kernel/commsSlots/state/makeGetNextImportID.js
+++ b/src/kernel/commsSlots/state/makeGetNextImportID.js
@@ -1,0 +1,14 @@
+export function makeGetNextImportID() {
+  let nextImportID = 1;
+
+  return {
+    getNextImportID() {
+      const id = nextImportID;
+      nextImportID += 1;
+      return id;
+    },
+    dump() {
+      return JSON.stringify(nextImportID);
+    },
+  };
+}

--- a/src/kernel/commsSlots/state/makeMachineState.js
+++ b/src/kernel/commsSlots/state/makeMachineState.js
@@ -1,0 +1,24 @@
+export function makeMachineState() {
+  let myMachineName;
+  let myProofMaterial;
+  return {
+    getMachineName() {
+      return myMachineName;
+    },
+    getProofMaterial() {
+      return myProofMaterial;
+    },
+    setMachineName(machineName) {
+      myMachineName = machineName;
+    },
+    setProofMaterial(proofMaterial) {
+      myProofMaterial = proofMaterial;
+    },
+    dump() {
+      return JSON.stringify({
+        myMachineName: `${myMachineName}`,
+        myProofMaterial: `${myProofMaterial}`,
+      });
+    },
+  };
+}

--- a/src/kernel/commsSlots/state/makeSubscribers.js
+++ b/src/kernel/commsSlots/state/makeSubscribers.js
@@ -1,0 +1,20 @@
+// Subscribers
+
+export function makeSubscribers() {
+  const subscribersMap = new Map(); // promiseID -> senderID
+
+  return {
+    add(promiseID, senderID) {
+      if (!subscribersMap.get(promiseID)) {
+        subscribersMap.set(promiseID, []);
+      }
+      subscribersMap.get(promiseID).push(senderID);
+    },
+    get(promiseID) {
+      return subscribersMap.get(promiseID);
+    },
+    dump() {
+      return subscribersMap;
+    },
+  };
+}

--- a/src/kernel/kernel.js
+++ b/src/kernel/kernel.js
@@ -1,6 +1,7 @@
 import harden from '@agoric/harden';
 import Nat from '@agoric/nat';
 import { makeLiveSlots } from './liveSlots';
+import { makeCommsSlots } from './commsSlots/index';
 import { QCLASS, makeMarshal } from './marshal';
 import makePromise from './makePromise';
 import makeVatManager from './vatManager';
@@ -219,6 +220,7 @@ export default function buildKernel(kernelEndowments) {
     const helpers = harden({
       vatID,
       makeLiveSlots,
+      makeCommsSlots,
       log(str) {
         log.push(`${str}`);
       },

--- a/test/basedir-commsvat/bootstrap.js
+++ b/test/basedir-commsvat/bootstrap.js
@@ -1,0 +1,78 @@
+import harden from '@agoric/harden';
+
+console.log(`=> loading bootstrap.js`);
+
+export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+  }
+  log(`=> setup called`);
+
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E =>
+      harden({
+        async bootstrap(argv, vats) {
+          log('=> bootstrap() called');
+
+          const LEFT_MACHINE_NAME = 'left';
+          const RIGHT_MACHINE_NAME = 'right';
+          const CHANNEL = 'channel';
+          const RIGHT_CLIST_INDEX = 0;
+
+          await E(vats.rightcomms).init(RIGHT_MACHINE_NAME, 'rightSigningKey');
+          await E(vats.leftcomms).init(LEFT_MACHINE_NAME, 'leftSigningKey');
+
+          await E(vats.rightcomms).connect(
+            LEFT_MACHINE_NAME,
+            'leftVerifyingKey',
+            CHANNEL,
+          );
+          await E(vats.leftcomms).connect(
+            RIGHT_MACHINE_NAME,
+            'rightVerifyingKey',
+            CHANNEL,
+          );
+
+          await E(vats.rightcomms).addExport(
+            LEFT_MACHINE_NAME,
+            RIGHT_CLIST_INDEX,
+            vats.right,
+          );
+
+          const pPRootRight = E(vats.leftcomms).addImport(
+            RIGHT_MACHINE_NAME,
+            RIGHT_CLIST_INDEX,
+          ); // the promise for the presence of right root object
+
+          const test = argv[0];
+          const args = argv.slice(1);
+          if (test === 'method' || test === 'methodWithArgs') {
+            E(vats.left).callMethodOnPresence(pPRootRight, args);
+          }
+          if (test === 'methodWithRef') {
+            pPRootRight.then(
+              rootRightPresence => {
+                log(`rootRightPresence ${rootRightPresence}`);
+                E(vats.left)
+                  .callMethodOnPresenceWithRef(rootRightPresence)
+                  .then(
+                    r =>
+                      log(
+                        `=> the promise given by the call to left.callMethodOnPresenceWithRef resolved to '${r}'`,
+                      ),
+                    err =>
+                      log(
+                        `=> the promise given by the call to left.callMethodOnPresenceWithRef was rejected '${err}''`,
+                      ),
+                  );
+              },
+              err => log(`${err}`),
+            );
+          }
+        },
+      }),
+    helpers.vatID,
+  );
+}

--- a/test/basedir-commsvat/vat-left.js
+++ b/test/basedir-commsvat/vat-left.js
@@ -1,0 +1,36 @@
+import harden from '@agoric/harden';
+
+export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+  }
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E =>
+      harden({
+        callMethodOnPresence(presence, args) {
+          log(`=> left.callMethodOnPresence is called with args: [${args}]`);
+          if (args.length <= 0) {
+            E(presence).method();
+          } else {
+            E(presence)
+              .takeArgAndReturnData(args)
+              .then(returnedData => {
+                log(`=> left vat receives the returnedData: ${returnedData}`);
+              });
+          }
+          return 'presence was called';
+        },
+        callMethodOnPresenceWithRef(presence) {
+          E(presence)
+            .takeReferenceEqualToTargetAndReturnData(presence)
+            .then(returnedData => {
+              log(`=> left vat receives the returnedData: ${returnedData}`);
+            });
+          return 'presence was called';
+        },
+      }),
+    helpers.vatID,
+  );
+}

--- a/test/basedir-commsvat/vat-leftcomms.js
+++ b/test/basedir-commsvat/vat-leftcomms.js
@@ -1,0 +1,3 @@
+export default function setup(syscall, state, helpers, devices) {
+  return helpers.makeCommsSlots(syscall, state, helpers, devices);
+}

--- a/test/basedir-commsvat/vat-right.js
+++ b/test/basedir-commsvat/vat-right.js
@@ -1,0 +1,29 @@
+import harden from '@agoric/harden';
+
+export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+  }
+
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    _E =>
+      harden({
+        method() {
+          log(`=> right.method was invoked`);
+        },
+        takeArgAndReturnData(arg) {
+          log(`=> right.takeArgAndReturnData got the arg: ${arg}`);
+          return `${arg} was received`;
+        },
+        takeReferenceEqualToTargetAndReturnData(ref) {
+          log(
+            `=> right.takeReferenceEqualToTargetAndReturnData got the arg: ${ref}`,
+          );
+          return `ref was received`;
+        },
+      }),
+    helpers.vatID,
+  );
+}

--- a/test/basedir-commsvat/vat-rightcomms.js
+++ b/test/basedir-commsvat/vat-rightcomms.js
@@ -1,0 +1,3 @@
+export default function setup(syscall, state, helpers, devices) {
+  return helpers.makeCommsSlots(syscall, state, helpers, devices);
+}

--- a/test/commsSlots-integration/test-commsvats.js
+++ b/test/commsSlots-integration/test-commsvats.js
@@ -1,0 +1,112 @@
+import path from 'path';
+import { test } from 'tape-promise/tape';
+import { buildVatController, loadBasedir } from '../../src/index';
+
+// 1. Invoke method on other machine with no arguments - don’t look at return value
+// 2. Invoke with argument all the way through
+// 3. Pass reference through - where reference is the same as the target
+// 4. Pass reference through where the reference is one of the sending vats’ objects. Test by invoking a method
+// 5. Should recognize is not yet exported
+// 6. Send a message ignoring arguments and get a promise back for the result
+// 7. Promise resolving to a slot - two different sides for that slots
+// 8. Slot that exists on my machine, slot on their machine
+// 9. Something that represents promises over the wire
+// 10. Passing promises as arguments, resvoling a promise to an array that contains a promise
+
+const { buildChannel } = require('../../src/devices');
+
+async function runTest(t, withSES, argv) {
+  const config = await loadBasedir(
+    path.resolve(__dirname, '../basedir-commsvat'),
+  );
+
+  const channelDevice = buildChannel();
+  const vatDevices = new Map();
+  const commsConfig = {
+    devices: {
+      channel: {
+        attenuatorSource: channelDevice.attenuatorSource,
+        bridge: channelDevice.bridge,
+      },
+    },
+  };
+
+  for (const vatID of config.vatSources.keys()) {
+    if (vatID.endsWith('comms')) {
+      vatDevices.set(vatID, commsConfig);
+    }
+  }
+
+  if (vatDevices.size > 0) {
+    config.vatDevices = vatDevices;
+  }
+  const c = await buildVatController(config, withSES, argv);
+  return c;
+}
+
+test('Invoke method on other machine with no arguments', async t => {
+  const c = await runTest(t, false, ['method']);
+  await c.run();
+  const { log } = c.dump();
+  t.deepEqual(log, [
+    '=> setup called',
+    '=> bootstrap() called',
+    'init called with name right',
+    'init called with name left',
+    'connect called with otherMachineName left, channelName channel',
+    'connect called with otherMachineName right, channelName channel',
+    'addExport called with sender left, index 0',
+    'addImport called with machineName right, index 0',
+    '=> left.callMethodOnPresence is called with args: []',
+    'sendOverChannel from left, to: right message: {"index":0,"methodName":"method","args":[],"slots":[],"resultIndex":33}',
+    '=> right.method was invoked',
+    'sendOverChannel from right, to: left: {"event":"notifyFulfillToData","resolverID":33,"data":"{\\"@qclass\\":\\"undefined\\"}"}',
+  ]);
+  // do we want qclass undefined for no return??
+  t.end();
+});
+
+test('Invoke method with argument on other machine', async t => {
+  const c = await runTest(t, false, ['methodWithArgs', 'hello']);
+  await c.run();
+  const { log } = c.dump();
+  t.deepEqual(log, [
+    '=> setup called',
+    '=> bootstrap() called',
+    'init called with name right',
+    'init called with name left',
+    'connect called with otherMachineName left, channelName channel',
+    'connect called with otherMachineName right, channelName channel',
+    'addExport called with sender left, index 0',
+    'addImport called with machineName right, index 0',
+    '=> left.callMethodOnPresence is called with args: [hello]',
+    'sendOverChannel from left, to: right message: {"index":0,"methodName":"takeArgAndReturnData","args":[["hello"]],"slots":[],"resultIndex":33}',
+    '=> right.takeArgAndReturnData got the arg: hello',
+    'sendOverChannel from right, to: left: {"event":"notifyFulfillToData","resolverID":33,"data":"\\"hello was received\\""}',
+    '=> left vat receives the returnedData: hello was received',
+  ]);
+  t.end();
+});
+
+test('Pass reference through - where reference is the same as the target', async t => {
+  const c = await runTest(t, false, ['methodWithRef']);
+  await c.run();
+  const dump = c.dump();
+  t.deepEqual(dump.log, [
+    '=> setup called',
+    '=> bootstrap() called',
+    'init called with name right',
+    'init called with name left',
+    'connect called with otherMachineName left, channelName channel',
+    'connect called with otherMachineName right, channelName channel',
+    'addExport called with sender left, index 0',
+    'addImport called with machineName right, index 0',
+    'rootRightPresence [object Object]',
+    'sendOverChannel from left, to: right message: {"index":0,"methodName":"takeReferenceEqualToTargetAndReturnData","args":[{"@qclass":"slot","index":0}],"slots":[{"type":"export","index":0}],"resultIndex":33}',
+    "=> the promise given by the call to left.callMethodOnPresenceWithRef resolved to 'presence was called'",
+    '=> right.takeReferenceEqualToTargetAndReturnData got the arg: [object Object]',
+    'sendOverChannel from right, to: left: {"event":"notifyFulfillToData","resolverID":33,"data":"\\"ref was received\\""}',
+    '=> left vat receives the returnedData: ref was received',
+  ]);
+  t.end();
+});

--- a/test/commsSlots/handleBootstrap/test-addExport.js
+++ b/test/commsSlots/handleBootstrap/test-addExport.js
@@ -1,0 +1,48 @@
+import { test } from 'tape-promise/tape';
+import handleBootstrap from '../../../src/kernel/commsSlots/handleBootstrap';
+import makeState from '../../../src/kernel/commsSlots/state';
+
+test('handleBootstrap addExport', t => {
+  let fulfillToDataArgs;
+
+  const mockSyscall = {
+    fulfillToData(...args) {
+      fulfillToDataArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  const resolverID = 2;
+  const sender = 'user';
+  const index = 0;
+  const valslot = { '@qclass': 'slot', index: 0 };
+  const caps = [{ type: 'import', id: 10 }];
+  const helpers = {
+    log: console.log,
+  };
+
+  const result = handleBootstrap(
+    state,
+    mockSyscall,
+    'addExport',
+    JSON.stringify({
+      args: [sender, index, valslot],
+    }),
+    caps,
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToDataArgs, [resolverID, JSON.stringify('undefined'), []]);
+
+  // ensure state updated correctly
+  const kernelExport = state.clists.getKernelExport('outbound', sender, index);
+  const machineInfo = state.clists.getMachine('outbound', caps[index]);
+  t.deepEqual(kernelExport, caps[index]); // actual, expected
+  t.equal(machineInfo.machineName, sender);
+  t.end();
+});

--- a/test/commsSlots/handleBootstrap/test-addImport.js
+++ b/test/commsSlots/handleBootstrap/test-addImport.js
@@ -1,0 +1,205 @@
+import { test } from 'tape-promise/tape';
+import handleBootstrap from '../../../src/kernel/commsSlots/handleBootstrap';
+import makeState from '../../../src/kernel/commsSlots/state';
+
+const helpers = {
+  log: console.log,
+};
+
+test('handleBootstrap addImport', t => {
+  let fulfillToTargetArgs;
+
+  const mockSyscall = {
+    fulfillToTarget(...args) {
+      fulfillToTargetArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  const resolverID = 2;
+  const sender = 'bot';
+  const index = 0;
+
+  const result = handleBootstrap(
+    state,
+    mockSyscall,
+    'addImport',
+    JSON.stringify({
+      args: [sender, 0],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToTargetArgs, [
+    resolverID,
+    {
+      type: 'export',
+      id: 1, // first import is 1
+    },
+  ]);
+
+  // ensure state updated correctly
+  const kernelExport = state.clists.getKernelExport('inbound', sender, index);
+  const machineInfo = state.clists.getMachine('inbound', 1);
+  t.equal(kernelExport, 1); // actual, expected
+  t.equal(machineInfo.machineName, sender);
+  t.end();
+});
+
+test('handleBootstrap addImport twice', t => {
+  let fulfillToTargetArgs;
+
+  const mockSyscall = {
+    fulfillToTarget(...args) {
+      fulfillToTargetArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  const resolverID = 2;
+  const sender = 'bot';
+  const sender2 = 'user';
+  const index = 0;
+
+  const result = handleBootstrap(
+    state,
+    mockSyscall,
+    'addImport',
+    JSON.stringify({
+      args: [sender, 0],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToTargetArgs, [
+    resolverID,
+    {
+      type: 'export',
+      id: 1, // first import is 1
+    },
+  ]);
+
+  // ensure state updated correctly
+  const kernelExport = state.clists.getKernelExport('inbound', sender, index);
+  const machineInfo = state.clists.getMachine('inbound', 1);
+  t.equal(kernelExport, 1); // actual, expected
+  t.equal(machineInfo.machineName, sender);
+
+  const result2 = handleBootstrap(
+    state,
+    mockSyscall,
+    'addImport',
+    JSON.stringify({
+      args: [sender2, 0],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result2, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToTargetArgs, [
+    resolverID,
+    {
+      type: 'export',
+      id: 2,
+    },
+  ]);
+
+  // ensure state updated correctly
+  const kernelExport2 = state.clists.getKernelExport('inbound', sender2, index);
+  const machineInfo2 = state.clists.getMachine('inbound', 2);
+  t.equal(kernelExport2, 2); // actual, expected
+  t.equal(machineInfo2.machineName, sender2);
+  t.end();
+});
+
+test('handleBootstrap addImport same again', t => {
+  let fulfillToTargetArgs;
+
+  const mockSyscall = {
+    fulfillToTarget(...args) {
+      fulfillToTargetArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  const resolverID = 2;
+  const sender = 'bot';
+  const index = 0;
+
+  const result = handleBootstrap(
+    state,
+    mockSyscall,
+    'addImport',
+    JSON.stringify({
+      args: [sender, 0],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToTargetArgs, [
+    resolverID,
+    {
+      type: 'export',
+      id: 1, // first import is 1
+    },
+  ]);
+
+  // ensure state updated correctly
+  const kernelExport = state.clists.getKernelExport('inbound', sender, index);
+  const machineInfo = state.clists.getMachine('inbound', 1);
+  t.equal(kernelExport, 1); // actual, expected
+  t.equal(machineInfo.machineName, sender);
+
+  const result2 = handleBootstrap(
+    state,
+    mockSyscall,
+    'addImport',
+    JSON.stringify({
+      args: [sender, 0],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result2, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToTargetArgs, [
+    resolverID,
+    {
+      type: 'export',
+      id: 1, // first import is 1
+    },
+  ]);
+
+  // ensure state updated correctly
+  const kernelExport2 = state.clists.getKernelExport('inbound', sender, index);
+  const machineInfo2 = state.clists.getMachine('inbound', 1);
+  t.equal(kernelExport2, 1); // actual, expected
+  t.equal(machineInfo2.machineName, sender);
+
+  t.end();
+});

--- a/test/commsSlots/handleBootstrap/test-connect.js
+++ b/test/commsSlots/handleBootstrap/test-connect.js
@@ -1,0 +1,46 @@
+import { test } from 'tape-promise/tape';
+import handleBootstrap from '../../../src/kernel/commsSlots/handleBootstrap';
+import makeState from '../../../src/kernel/commsSlots/state';
+
+const helpers = {
+  log: console.log,
+};
+
+test('handleBootstrap connect update channels', t => {
+  let fulfillToDataArgs;
+
+  const mockSyscall = {
+    fulfillToData(...args) {
+      fulfillToDataArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  const otherMachineName = 'machine1';
+  const verifyingKey = 'key1';
+  const deviceName = 'channel';
+  const resolverID = 2;
+
+  const result = handleBootstrap(
+    state,
+    mockSyscall,
+    'connect',
+    JSON.stringify({
+      args: [otherMachineName, verifyingKey, deviceName],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToDataArgs, [resolverID, JSON.stringify('undefined'), []]);
+
+  // ensure state updated correctly
+  const channel = state.channels.getChannelDevice(otherMachineName);
+  t.equal(channel, deviceName);
+  t.end();
+});

--- a/test/commsSlots/handleBootstrap/test-init.js
+++ b/test/commsSlots/handleBootstrap/test-init.js
@@ -1,0 +1,114 @@
+import { test } from 'tape-promise/tape';
+import handleBootstrap from '../../../src/kernel/commsSlots/handleBootstrap';
+import makeState from '../../../src/kernel/commsSlots/state';
+
+const helpers = {
+  log: console.log,
+};
+
+test('handleBootstrap init update machineState', t => {
+  let fulfillToDataArgs;
+
+  const mockSyscall = {
+    fulfillToData(...args) {
+      fulfillToDataArgs = args;
+    },
+  };
+
+  const state = makeState();
+  t.equal(state.machineState.getMachineName(), undefined);
+  t.equal(state.machineState.getProofMaterial(), undefined);
+
+  const newMachineName = 'machine1';
+  const newProofMaterial = 'proofMaterial1';
+  const resolverID = 2;
+
+  const result = handleBootstrap(
+    state,
+    mockSyscall,
+    'init',
+    JSON.stringify({
+      args: [newMachineName, newProofMaterial],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToDataArgs, [
+    resolverID,
+    JSON.stringify(newMachineName),
+    [],
+  ]);
+
+  // ensure state updated correctly
+  const currentMachineName = state.machineState.getMachineName();
+  const currentProofMaterial = state.machineState.getProofMaterial();
+  t.equal(currentMachineName, newMachineName);
+  t.equal(currentProofMaterial, newProofMaterial);
+  t.end();
+});
+
+test('handleBootstrap init: only init once', t => {
+  let fulfillToDataArgs;
+
+  const mockSyscall = {
+    fulfillToData(...args) {
+      fulfillToDataArgs = args;
+    },
+  };
+
+  const state = makeState();
+  t.equal(state.machineState.getMachineName(), undefined);
+  t.equal(state.machineState.getProofMaterial(), undefined);
+
+  const newMachineName = 'machine1';
+  const newProofMaterial = 'proofMaterial1';
+  const resolverID = 2;
+
+  const result = handleBootstrap(
+    state,
+    mockSyscall,
+    'init',
+    JSON.stringify({
+      args: [newMachineName, newProofMaterial],
+    }),
+    [],
+    resolverID,
+    helpers,
+  );
+
+  t.equal(result, undefined);
+
+  // ensure calls to syscall are correct
+  t.deepEqual(fulfillToDataArgs, [
+    resolverID,
+    JSON.stringify(newMachineName),
+    [],
+  ]);
+
+  // ensure state updated correctly
+  const currentMachineName = state.machineState.getMachineName();
+  const currentProofMaterial = state.machineState.getProofMaterial();
+  t.equal(currentMachineName, newMachineName);
+  t.equal(currentProofMaterial, newProofMaterial);
+
+  t.throws(() => {
+    return handleBootstrap(
+      state,
+      mockSyscall,
+      'init',
+      JSON.stringify({
+        args: [newMachineName, newProofMaterial],
+      }),
+      [],
+      resolverID,
+      helpers,
+    );
+  });
+
+  t.end();
+});

--- a/test/commsSlots/makeCommsSlots/test-deliver.js
+++ b/test/commsSlots/makeCommsSlots/test-deliver.js
@@ -1,0 +1,94 @@
+import { test } from 'tape-promise/tape';
+import { makeCommsSlots } from '../../../src/kernel/commsSlots';
+
+const helpers = {
+  log: console.log,
+  vatID: 'botcomms',
+};
+
+test('makeCommsSlots deliver facetid is 0', t => {
+  let fulfillToDataArgs;
+
+  const mockSyscall = {
+    fulfillToData(...args) {
+      fulfillToDataArgs = args;
+    },
+  };
+
+  const commsSlots = makeCommsSlots(mockSyscall, {}, helpers, {});
+  commsSlots.deliver(0, 'init', '{"args":["bot","botSigningKey"]}', [], 30); // init
+  // confirm that init is called, we are already testing init in handleBootstrap
+  t.deepEqual(fulfillToDataArgs, [30, JSON.stringify('bot'), []]);
+  t.end();
+});
+
+test('makeCommsSlots deliver facetid is unexpected', t => {
+  let fulfillToDataArgs;
+
+  const mockSyscall = {
+    fulfillToData(...args) {
+      fulfillToDataArgs = args;
+    },
+  };
+
+  const commsSlots = makeCommsSlots(mockSyscall, {}, helpers, {});
+
+  t.throws(() => {
+    commsSlots.deliver(1, 'init', '{"args":["bot","botSigningKey"]}', [], 30);
+  }, "{[Error: unknown facetid] message: 'unknown facetid' }");
+  t.equal(fulfillToDataArgs, undefined);
+  t.end();
+});
+
+test('makeCommsSlots deliver facetid is nonzero and expected', t => {
+  let fulfillToTargetArgs;
+  let fulfillToDataArgs;
+
+  const mockSyscall = {
+    fulfillToTarget(...args) {
+      fulfillToTargetArgs = args;
+    },
+    fulfillToData(...args) {
+      fulfillToDataArgs = args;
+    },
+  };
+
+  let sentData;
+  function sendOverChannel(fromMachineName, toMachineName, data) {
+    sentData = data;
+  }
+  function registerInboundCallback(_cb) {}
+
+  const commsSlots = makeCommsSlots(mockSyscall, {}, helpers, {
+    channel: {
+      sendOverChannel,
+      registerInboundCallback,
+    },
+  });
+
+  commsSlots.deliver(
+    0,
+    'connect',
+    '{"args":["bot","botVerifyingKey","channel"]}',
+    [],
+    31,
+  );
+
+  const state = commsSlots.getState();
+
+  state.machineState.setMachineName('bot');
+  state.channels.add('machine1', 'channel');
+
+  // setup with an addImport
+  commsSlots.deliver(0, 'addImport', '{"args":["bot",0]}', [], 32);
+  t.deepEqual(fulfillToTargetArgs, [32, { type: 'export', id: 1 }]);
+
+  commsSlots.deliver(1, 'encourageMe', '{"args":["user"]}', [], 33);
+  t.deepEqual(fulfillToDataArgs, [31, '"undefined"', []]);
+
+  t.equal(
+    sentData,
+    '{"index":0,"methodName":"encourageMe","args":["user"],"slots":[],"resultIndex":33}',
+  );
+  t.end();
+});

--- a/test/commsSlots/makeCommsSlots/test-notifyFulfillToData.js
+++ b/test/commsSlots/makeCommsSlots/test-notifyFulfillToData.js
@@ -1,0 +1,49 @@
+import { test } from 'tape-promise/tape';
+import { makeCommsSlots } from '../../../src/kernel/commsSlots';
+
+const helpers = {
+  log: console.log,
+  vatID: 'botcomms',
+};
+
+test('makeCommsSlots notifyFulfillToData', t => {
+  const mockSyscall = {};
+
+  let sentData;
+  let fMachineName;
+  let tMachineName;
+
+  function sendOverChannel(fromMachineName, toMachineName, data) {
+    fMachineName = fromMachineName;
+    tMachineName = toMachineName;
+    sentData = data;
+  }
+
+  const commsSlots = makeCommsSlots(mockSyscall, {}, helpers, {
+    channel: {
+      sendOverChannel,
+    },
+  });
+
+  const promiseID = 22;
+
+  // setup
+  const state = commsSlots.getState();
+  state.clists.add('outbound', helpers, 1, {
+    type: 'promise',
+    id: promiseID,
+  });
+
+  state.machineState.setMachineName('bot');
+  state.subscribers.add(promiseID, 'machine1');
+  state.channels.add('machine1', 'channel');
+
+  commsSlots.notifyFulfillToData(22, 'hello', []);
+  t.equal(fMachineName, 'bot');
+  t.equal(tMachineName, 'machine1');
+  t.equal(
+    sentData,
+    '{"event":"notifyFulfillToData","resolverID":1,"data":"hello"}',
+  );
+  t.end();
+});

--- a/test/commsSlots/makeCommsSlots/test-notifyFulfillToTarget.js
+++ b/test/commsSlots/makeCommsSlots/test-notifyFulfillToTarget.js
@@ -1,0 +1,46 @@
+import { test } from 'tape-promise/tape';
+import { makeCommsSlots } from '../../../src/kernel/commsSlots';
+
+const helpers = {
+  log: console.log,
+  vatID: 'botcomms',
+};
+
+test('makeCommsSlots notifyFulfillToTarget', t => {
+  const mockSyscall = {};
+
+  let sentData;
+  let fMachineName;
+  let tMachineName;
+
+  function sendOverChannel(fromMachineName, toMachineName, data) {
+    fMachineName = fromMachineName;
+    tMachineName = toMachineName;
+    sentData = data;
+  }
+
+  const commsSlots = makeCommsSlots(mockSyscall, {}, helpers, {
+    channel: {
+      sendOverChannel,
+    },
+  });
+
+  const state = commsSlots.getState();
+
+  state.subscribers.add(20, 'abc');
+  state.channels.add('abc', 'channel');
+  state.machineState.setMachineName('bot');
+
+  commsSlots.notifyFulfillToTarget(20, {
+    type: 'import',
+    id: 11,
+  });
+
+  t.equal(fMachineName, 'bot');
+  t.equal(tMachineName, 'abc');
+  t.equal(
+    sentData,
+    '{"event":"notifyFulfillToTarget","promiseID":20,"target":{"type":"import","id":11}}',
+  );
+  t.end();
+});

--- a/test/commsSlots/state/test-makeCLists.js
+++ b/test/commsSlots/state/test-makeCLists.js
@@ -1,0 +1,12 @@
+import { test } from 'tape-promise/tape';
+import { makeCLists } from '../../../src/kernel/commsSlots/state/makeCLists';
+
+test('Clists add and get', t => {
+  const clists = makeCLists();
+  clists.add('inbound', 'machine0', 'key0', 'value0');
+  const value = clists.getKernelExport('inbound', 'machine0', 'key0');
+  t.equal(value, 'value0');
+  const machineInfo = clists.getMachine('inbound', 'value0');
+  t.equal(machineInfo.machineName, 'machine0');
+  t.end();
+});

--- a/test/commsSlots/state/test-makeChannels.js
+++ b/test/commsSlots/state/test-makeChannels.js
@@ -1,0 +1,10 @@
+import { test } from 'tape-promise/tape';
+import { makeChannels } from '../../../src/kernel/commsSlots/state/makeChannels';
+
+test('channels add and get', t => {
+  const channels = makeChannels();
+  channels.add('machine1', 'channel1'); // we assume that machines and channels are one to one.
+  const channel = channels.getChannelDevice('machine1');
+  t.equal(channel, 'channel1');
+  t.end();
+});

--- a/test/commsSlots/state/test-makeGetNextImportID.js
+++ b/test/commsSlots/state/test-makeGetNextImportID.js
@@ -1,0 +1,11 @@
+import { test } from 'tape-promise/tape';
+import { makeGetNextImportID } from '../../../src/kernel/commsSlots/state/makeGetNextImportID';
+
+test('getNextImportID', t => {
+  const id = makeGetNextImportID();
+  const id1 = id.getNextImportID();
+  const id2 = id.getNextImportID();
+  t.equal(id1, 1);
+  t.equal(id2, 2);
+  t.end();
+});

--- a/test/commsSlots/state/test-makeMachineState.js
+++ b/test/commsSlots/state/test-makeMachineState.js
@@ -1,0 +1,22 @@
+import { test } from 'tape-promise/tape';
+import { makeMachineState } from '../../../src/kernel/commsSlots/state/makeMachineState';
+
+test('machineState set and get', t => {
+  const machineState = makeMachineState();
+  t.equal(machineState.getMachineName(), undefined);
+  t.equal(machineState.getProofMaterial(), undefined);
+  machineState.setMachineName('alice');
+  machineState.setProofMaterial('proof');
+  t.equal(machineState.getMachineName(), 'alice');
+  t.equal(machineState.getProofMaterial(), 'proof');
+
+  // test that it creates a new instance
+  const otherMachineState = makeMachineState();
+  t.equal(otherMachineState.getMachineName(), undefined);
+  t.equal(otherMachineState.getProofMaterial(), undefined);
+  otherMachineState.setMachineName('alice');
+  otherMachineState.setProofMaterial('proof');
+  t.equal(otherMachineState.getMachineName(), 'alice');
+  t.equal(otherMachineState.getProofMaterial(), 'proof');
+  t.end();
+});

--- a/test/commsSlots/state/test-makeSubscribers.js
+++ b/test/commsSlots/state/test-makeSubscribers.js
@@ -1,0 +1,11 @@
+import { test } from 'tape-promise/tape';
+import { makeSubscribers } from '../../../src/kernel/commsSlots/state/makeSubscribers';
+
+test('subscribers add and get', t => {
+  const subscribers = makeSubscribers();
+  subscribers.add(22, 'abc');
+  subscribers.add(23, 'abc');
+  const promiseSubscribers = subscribers.get(22);
+  t.deepEqual(promiseSubscribers, ['abc']);
+  t.end();
+});

--- a/test/commsSlots/test-sendIn.js
+++ b/test/commsSlots/test-sendIn.js
@@ -1,0 +1,278 @@
+import { test } from 'tape-promise/tape';
+import { makeSendIn } from '../../src/kernel/commsSlots/makeSendIn';
+import makeState from '../../src/kernel/commsSlots/state';
+
+// send [ { type: 'import', id: 10 }, 'getIssuer', '{"args":[]}', [] ]
+// subscribe 20
+test('SendIn Cosmos-SwingSet 0', t => {
+  let sentArgs;
+  let subscribeArgs;
+
+  const senderID = 'abc';
+  const promiseID = 72;
+
+  const mockSyscall = {
+    send(...args) {
+      sentArgs = args;
+      return promiseID;
+    },
+    subscribe(...args) {
+      subscribeArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  state.clists.add('outbound', senderID, 0, { type: 'import', id: 10 });
+
+  const { sendIn } = makeSendIn(state, mockSyscall);
+  sendIn(
+    senderID,
+    JSON.stringify({
+      index: 0,
+      methodName: 'getIssuer',
+      args: [],
+      slots: [],
+      resultIndex: 1,
+    }),
+  );
+  // ensure calls to syscall are correct
+  t.deepEqual(sentArgs, [
+    { type: 'import', id: 10 },
+    'getIssuer',
+    '{"args":[]}',
+    [],
+  ]);
+  t.deepEqual(subscribeArgs, [promiseID]);
+
+  // ensure state updated correctly
+  const storedPromise = state.clists.getKernelExport('outbound', senderID, 1);
+  t.deepEqual(storedPromise, {
+    type: 'promise',
+    id: promiseID,
+  });
+  const storedSubscribers = state.subscribers.get(promiseID);
+  t.deepEqual(storedSubscribers, [senderID]);
+  t.end();
+});
+
+// send [ {type: "promise", id: 20}, 'makeEmptyPurse', {"args":["purse2"]}, [] ]
+// subscribe 21
+test('SendIn Cosmos-SwingSet 1', t => {
+  let sentArgs;
+  let subscribeArgs;
+
+  const senderID = 'abc';
+  const promiseID = 72;
+
+  const mockSyscall = {
+    send(...args) {
+      sentArgs = args;
+      return promiseID;
+    },
+    subscribe(...args) {
+      subscribeArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  state.clists.add('outbound', senderID, 0, { type: 'import', id: 10 });
+  state.clists.add('outbound', senderID, 1, { type: 'promise', id: 20 });
+  const { sendIn } = makeSendIn(state, mockSyscall);
+  sendIn(
+    senderID,
+    JSON.stringify({
+      index: 1,
+      methodName: 'makeEmptyPurse',
+      args: ['purse2'],
+      slots: [],
+      resultIndex: 2,
+    }),
+  );
+
+  // ensure calls to syscall are correct
+  t.deepEqual(sentArgs, [
+    { type: 'promise', id: 20 },
+    'makeEmptyPurse',
+    '{"args":["purse2"]}',
+    [],
+  ]);
+  t.deepEqual(subscribeArgs, [promiseID]);
+
+  // ensure state updated correctly
+  const storedPromise = state.clists.getKernelExport('outbound', senderID, 2);
+  t.deepEqual(storedPromise, {
+    type: 'promise',
+    id: promiseID,
+  });
+  const storedSubscribers = state.subscribers.get(promiseID);
+  t.deepEqual(storedSubscribers, [senderID]);
+  t.end();
+});
+
+// send [ {type: "promise", id: 21}, 'deposit', {"args":[20,{"@qclass":"slot","index":0}]}, [{type: "import", id: 10}] ]
+// subscribe 22
+test('SendIn Cosmos-SwingSet 2', t => {
+  let sentArgs;
+  let subscribeArgs;
+
+  const senderID = 'abc';
+  const promiseID = 72;
+
+  const mockSyscall = {
+    send(...args) {
+      sentArgs = args;
+      return promiseID;
+    },
+    subscribe(...args) {
+      subscribeArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  state.clists.add('outbound', senderID, 0, { type: 'import', id: 10 });
+  state.clists.add('outbound', senderID, 1, { type: 'promise', id: 20 });
+  state.clists.add('outbound', senderID, 2, { type: 'promise', id: 21 });
+  const { sendIn } = makeSendIn(state, mockSyscall);
+  sendIn(
+    senderID,
+    JSON.stringify({
+      index: 2,
+      methodName: 'deposit',
+      args: [20, { '@qclass': 'slot', index: 0 }],
+      slots: [{ type: 'export', index: 0 }],
+      resultIndex: 3,
+    }),
+  );
+
+  // ensure calls to syscall correct
+  t.deepEqual(sentArgs, [
+    { type: 'promise', id: 21 },
+    'deposit',
+    '{"args":[20,{"@qclass":"slot","index":0}]}',
+    [{ type: 'import', id: 10 }],
+  ]);
+  t.deepEqual(subscribeArgs, [promiseID]);
+
+  // ensure state changes correct
+  const storedPromise = state.clists.getKernelExport('outbound', senderID, 3);
+  t.deepEqual(storedPromise, {
+    type: 'promise',
+    id: promiseID,
+  });
+  const storedSubscribers = state.subscribers.get(promiseID);
+  t.deepEqual(storedSubscribers, [senderID]);
+  t.end();
+});
+
+// send [ {type: "promise", id: 21}, getBalance {"args":[]}, [] ]
+// subscribe 23
+test('SendIn Cosmos-SwingSet 3', t => {
+  let sentArgs;
+  let subscribeArgs;
+
+  const senderID = 'abc';
+  const promiseID = 72;
+
+  const mockSyscall = {
+    send(...args) {
+      sentArgs = args;
+      return promiseID;
+    },
+    subscribe(...args) {
+      subscribeArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  state.clists.add('outbound', senderID, 0, { type: 'import', id: 10 });
+  state.clists.add('outbound', senderID, 1, { type: 'promise', id: 20 });
+  state.clists.add('outbound', senderID, 2, { type: 'promise', id: 21 });
+  const { sendIn } = makeSendIn(state, mockSyscall);
+  sendIn(
+    senderID,
+    JSON.stringify({
+      index: 2,
+      methodName: 'getBalance',
+      args: [],
+      slots: [],
+      resultIndex: 4,
+    }),
+  );
+  // ensure syscall calls correct
+  t.deepEqual(sentArgs, [
+    { type: 'promise', id: 21 },
+    'getBalance',
+    '{"args":[]}',
+    [],
+  ]);
+  t.deepEqual(subscribeArgs, [promiseID]);
+
+  // ensure state changes correct
+  const storedPromise = state.clists.getKernelExport('outbound', senderID, 4);
+  t.deepEqual(storedPromise, {
+    type: 'promise',
+    id: promiseID,
+  });
+  const storedSubscribers = state.subscribers.get(promiseID);
+  t.deepEqual(storedSubscribers, [senderID]);
+  t.end();
+});
+
+// send [ {type: "import", id: 10}, getBalance {"args":[]}', [] ]
+// subscribe 24
+test('SendIn Cosmos-SwingSet 4', t => {
+  let sentArgs;
+  let subscribeArgs;
+
+  const senderID = 'abc';
+  const promiseID = 72;
+
+  const mockSyscall = {
+    send(...args) {
+      sentArgs = args;
+      return promiseID;
+    },
+    subscribe(...args) {
+      subscribeArgs = args;
+    },
+  };
+
+  const state = makeState();
+
+  state.clists.add('outbound', senderID, 0, { type: 'import', id: 10 });
+  state.clists.add('outbound', senderID, 1, { type: 'promise', id: 20 });
+  state.clists.add('outbound', senderID, 2, { type: 'promise', id: 21 });
+  const { sendIn } = makeSendIn(state, mockSyscall);
+  sendIn(
+    senderID,
+    JSON.stringify({
+      index: 0,
+      methodName: 'getBalance',
+      args: [],
+      slots: [],
+      resultIndex: 5,
+    }),
+  );
+  // ensure syscall calls correct
+  t.deepEqual(sentArgs, [
+    { type: 'import', id: 10 },
+    'getBalance',
+    '{"args":[]}',
+    [],
+  ]);
+  t.deepEqual(subscribeArgs, [promiseID]);
+
+  // ensure state changes correct
+  const storedPromise = state.clists.getKernelExport('outbound', senderID, 5);
+  t.deepEqual(storedPromise, {
+    type: 'promise',
+    id: promiseID,
+  });
+  const storedSubscribers = state.subscribers.get(promiseID);
+  t.deepEqual(storedSubscribers, [senderID]);
+  t.end();
+});


### PR DESCRIPTION
This PR adds a helper function `makeCommsSlots` that replaces the functionality of `liveSlots` for Comms vats. Comms vats are vats that are able to communicate with the outside world through a device. A vat that wants to communicate with another machine must go through the comms vat on their machine. 

Currently, the device has a mock connection, not a real one. 

This could use some clean up and better documentation especially regarding the state changes, but we wanted to merge this in before it went too far. 