### PR TITLE
Add tests for the demos

### DIFF
--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -17,7 +17,7 @@
 import harden from '@agoric/harden';
 import escrowExchange from './escrow';
 
-function makeAlice(E, host) {
+function makeAlice(E, host, log) {
   const escrowSrc = `(${escrowExchange})`;
 
   let initialized = false;
@@ -47,7 +47,7 @@ function makeAlice(E, host) {
     init,
     payBobWell(bob) {
       if (!initialized) {
-        console.log('++ ERR: payBobWell called before init()');
+        log('++ ERR: payBobWell called before init()');
       }
       const paymentP = E(myMoneyIssuerP).makeEmptyPurse();
       const ackP = E(paymentP).deposit(10, myMoneyPurseP);
@@ -55,14 +55,14 @@ function makeAlice(E, host) {
     },
     payBobBadly1(bob) {
       if (!initialized) {
-        console.log('++ ERR: payBobBadly1 called before init()');
+        log('++ ERR: payBobBadly1 called before init()');
       }
       const payment = harden({ deposit(_amount, _src) {} });
       return E(bob).buy('shoe', payment);
     },
     payBobBadly2(bob) {
       if (!initialized) {
-        console.log('++ ERR: payBobBadly2 called before init()');
+        log('++ ERR: payBobBadly2 called before init()');
       }
       const paymentP = E(myMoneyIssuerP).makeEmptyPurse();
       const ackP = E(paymentP).deposit(5, myMoneyPurseP);
@@ -71,7 +71,7 @@ function makeAlice(E, host) {
 
     tradeWell(bob) {
       if (!initialized) {
-        console.log('++ ERR: tradeWell called before init()');
+        log('++ ERR: tradeWell called before init()');
       }
       const tokensP = E(host).setup(escrowSrc);
       const aliceTokenP = tokensP.then(tokens => tokens[0]);
@@ -82,7 +82,7 @@ function makeAlice(E, host) {
 
     invite(tokenP, allegedSrc, allegedSide) {
       if (!initialized) {
-        console.log('++ ERR: invite called before init()');
+        log('++ ERR: invite called before init()');
       }
 
       check(allegedSrc, allegedSide);
@@ -107,10 +107,14 @@ function makeAlice(E, host) {
 }
 
 export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+    console.log(what);
+  }
   return helpers.makeLiveSlots(syscall, state, E =>
     harden({
       makeAlice(host) {
-        return harden(makeAlice(E, host));
+        return harden(makeAlice(E, host, log));
       },
     }),
   );

--- a/demo/contractHost/vat-bob.js
+++ b/demo/contractHost/vat-bob.js
@@ -17,7 +17,7 @@
 import harden from '@agoric/harden';
 import escrowExchange from './escrow';
 
-function makeBob(E, host) {
+function makeBob(E, host, log) {
   const escrowSrc = `(${escrowExchange})`;
 
   let initialized = false;
@@ -52,7 +52,7 @@ function makeBob(E, host) {
      */
     buy(desc, paymentP) {
       if (!initialized) {
-        console.log('++ ERR: buy called before init()');
+        log('++ ERR: buy called before init()');
       }
       /* eslint-disable-next-line no-unused-vars */
       let amount;
@@ -75,9 +75,9 @@ function makeBob(E, host) {
     },
 
     tradeWell(alice, bobLies = false) {
-      console.log('++ bob.tradeWell starting');
+      log('++ bob.tradeWell starting');
       if (!initialized) {
-        console.log('++ ERR: tradeWell called before init()');
+        log('++ ERR: tradeWell called before init()');
       }
       const tokensP = E(host).setup(escrowSrc);
       const aliceTokenP = tokensP.then(tokens => tokens[0]);
@@ -91,8 +91,8 @@ function makeBob(E, host) {
         E(bob).invite(bobTokenP, escrowSrc, 1),
       ]);
       doneP.then(
-        _res => console.log('++ bob.tradeWell done'),
-        rej => console.log('++ bob.tradeWell reject', rej),
+        _res => log('++ bob.tradeWell done'),
+        rej => log('++ bob.tradeWell reject', rej),
       );
       return doneP;
     },
@@ -104,11 +104,11 @@ function makeBob(E, host) {
      */
     invite(tokenP, allegedSrc, allegedSide) {
       if (!initialized) {
-        console.log('++ ERR: invite called before init()');
+        log('++ ERR: invite called before init()');
       }
-      console.log('++ bob.invite start');
+      log('++ bob.invite start');
       check(allegedSrc, allegedSide);
-      console.log('++ bob.invite passed check');
+      log('++ bob.invite passed check');
       /* eslint-disable-next-line no-unused-vars */
       let cancel;
       const b = harden({
@@ -120,16 +120,16 @@ function makeBob(E, host) {
       const ackP = E(b.stockSrcP).deposit(7, myStockPurseP);
 
       const doneP = ackP.then(_ => {
-        console.log('++ bob.invite ackP');
+        log('++ bob.invite ackP');
         return E(host).play(tokenP, allegedSrc, allegedSide, b);
       });
       return doneP.then(
         _ => {
-          console.log('++ bob.invite doneP');
+          log('++ bob.invite doneP');
           return E(b.moneyDstP).getBalance();
         },
         rej => {
-          console.log('++ bob.invite doneP reject', rej);
+          log('++ bob.invite doneP reject', rej);
         },
       );
     },
@@ -138,10 +138,14 @@ function makeBob(E, host) {
 }
 
 export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+    console.log(what);
+  }
   return helpers.makeLiveSlots(syscall, state, E =>
     harden({
       makeBob(host) {
-        return harden(makeBob(E, host));
+        return harden(makeBob(E, host, log));
       },
     }),
   );

--- a/test/test-demos.js
+++ b/test/test-demos.js
@@ -1,0 +1,310 @@
+import { test } from 'tape-promise/tape';
+
+const { buildChannel } = require('../src/devices');
+const { loadBasedir, buildVatController } = require('../src/index.js');
+
+async function main(withSES, basedir, argv) {
+  const channelDevice = buildChannel();
+  const vatDevices = new Map();
+  const commsConfig = {
+    devices: {
+      channel: {
+        attenuatorSource: channelDevice.attenuatorSource,
+        bridge: channelDevice.bridge,
+      },
+    },
+  };
+
+  const config = await loadBasedir(basedir);
+  for (const vatID of config.vatSources.keys()) {
+    if (vatID.endsWith('comms')) {
+      vatDevices.set(vatID, commsConfig);
+    }
+  }
+
+  if (vatDevices.size > 0) {
+    config.vatDevices = vatDevices;
+  }
+
+  const controller = await buildVatController(config, withSES, argv);
+  await controller.run();
+  return controller.dump();
+}
+
+test('run encouragementBot Demo with SES', async t => {
+  const dump = await main(true, 'demo/encouragementBot', []);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    '=> user.talkToBot is called with encouragementBot',
+    '=> encouragementBot.encourageMe got the name: user',
+    "=> the promise given by the call to user.talkToBot resolved to 'Thanks for the setup. I sure hope I get some encouragement...'",
+    '=> user receives the encouragement: user, you are awesome, keep it up!',
+  ]);
+  t.end();
+});
+
+test('run encouragementBot Demo without SES', async t => {
+  const dump = await main(false, 'demo/encouragementBot', []);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    '=> user.talkToBot is called with encouragementBot',
+    '=> encouragementBot.encourageMe got the name: user',
+    "=> the promise given by the call to user.talkToBot resolved to 'Thanks for the setup. I sure hope I get some encouragement...'",
+    '=> user receives the encouragement: user, you are awesome, keep it up!',
+  ]);
+  t.end();
+});
+
+test('run encouragementBotComms Demo with SES', async t => {
+  const dump = await main(true, 'demo/encouragementBotComms', []);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'init called with name bot',
+    'init called with name user',
+    'connect called with otherMachineName user, channelName channel',
+    'addExport called with sender user, index 0',
+    'connect called with otherMachineName bot, channelName channel',
+    'addImport called with machineName bot, index 0',
+    '=> user.talkToBot is called with bot',
+    'sendOverChannel from user, to: bot message: {"index":0,"methodName":"encourageMe","args":["user"],"slots":[],"resultIndex":33}',
+    "=> the promise given by the call to user.talkToBot resolved to 'Thanks for the setup. I sure hope I get some encouragement...'",
+    '=> encouragementBot.encourageMe got the name: user',
+    'sendOverChannel from bot, to: user: {"event":"notifyFulfillToData","resolverID":33,"data":"\\"user, you are awesome, keep it up!\\""}',
+    '=> user receives the encouragement: user, you are awesome, keep it up!',
+  ]);
+  t.end();
+});
+
+test('run encouragementBotComms Demo without SES', async t => {
+  const dump = await main(false, 'demo/encouragementBotComms');
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'init called with name bot',
+    'init called with name user',
+    'connect called with otherMachineName user, channelName channel',
+    'addExport called with sender user, index 0',
+    'connect called with otherMachineName bot, channelName channel',
+    'addImport called with machineName bot, index 0',
+    '=> user.talkToBot is called with bot',
+    'sendOverChannel from user, to: bot message: {"index":0,"methodName":"encourageMe","args":["user"],"slots":[],"resultIndex":33}',
+    "=> the promise given by the call to user.talkToBot resolved to 'Thanks for the setup. I sure hope I get some encouragement...'",
+    '=> encouragementBot.encourageMe got the name: user',
+    'sendOverChannel from bot, to: user: {"event":"notifyFulfillToData","resolverID":33,"data":"\\"user, you are awesome, keep it up!\\""}',
+    '=> user receives the encouragement: user, you are awesome, keep it up!',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --mint with SES', async t => {
+  const dump = await main(true, 'demo/contractHost', ['mint']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'starting mintTest',
+    'makeMint',
+    'makeEmptyPurse(deposit)',
+    'deposit[deposit]#1: bal=0 amt=50',
+    ' dep[deposit]#1 (post-P): bal=0 amt=50',
+    'getBalance',
+    'getBalance',
+    '++ balances:',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --mint without SES', async t => {
+  const dump = await main(false, 'demo/contractHost', ['mint']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'starting mintTest',
+    'makeMint',
+    'makeEmptyPurse(deposit)',
+    'deposit[deposit]#1: bal=0 amt=50',
+    ' dep[deposit]#1 (post-P): bal=0 amt=50',
+    'getBalance',
+    'getBalance',
+    '++ balances:',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --trivial with SES', async t => {
+  const dump = await main(true, 'demo/contractHost', ['trivial']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'starting trivialContractTest',
+    '++ eightP resolved to',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --trivial without SES', async t => {
+  const dump = await main(false, 'demo/contractHost', ['trivial']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'starting trivialContractTest',
+    '++ eightP resolved to',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --alice-first with SES', async t => {
+  const dump = await main(true, 'demo/contractHost', ['alice-first']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'makeMint',
+    'makeMint',
+    'makeEmptyPurse(undefined)',
+    'deposit[undefined]#1: bal=0 amt=10',
+    ' dep[undefined]#1 (post-P): bal=0 amt=10',
+    'deposit[undefined]#2: bal=1001 amt=10',
+    ' dep[undefined]#2 (post-P): bal=1001 amt=10',
+    '++ ifItFitsP done:',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --alice-first without SES', async t => {
+  const dump = await main(false, 'demo/contractHost', ['alice-first']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'makeMint',
+    'makeMint',
+    'makeEmptyPurse(undefined)',
+    'deposit[undefined]#1: bal=0 amt=10',
+    ' dep[undefined]#1 (post-P): bal=0 amt=10',
+    'deposit[undefined]#2: bal=1001 amt=10',
+    ' dep[undefined]#2 (post-P): bal=1001 amt=10',
+    '++ ifItFitsP done:',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --bob-first with SES', async t => {
+  const dump = await main(true, 'demo/contractHost', ['bob-first']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'makeMint',
+    'makeMint',
+    '++ bob.tradeWell starting',
+    '++ bob.invite start',
+    '++ bob.invite passed check',
+    'makeEmptyPurse(bobMoneyDst)',
+    'makeEmptyPurse(bobStockSrc)',
+    'makeEmptyPurse(aliceMoneySrc)',
+    'makeEmptyPurse(aliceStockDst)',
+    'deposit[bobStockSrc]#1: bal=0 amt=7',
+    'deposit[aliceMoneySrc]#2: bal=0 amt=10',
+    ' dep[bobStockSrc]#1 (post-P): bal=0 amt=7',
+    ' dep[aliceMoneySrc]#2 (post-P): bal=0 amt=10',
+    '++ bob.invite ackP',
+    'makeEmptyPurse(escrow)',
+    'makeEmptyPurse(escrow)',
+    'deposit[escrow]#3: bal=0 amt=10',
+    'deposit[escrow]#4: bal=0 amt=7',
+    ' dep[escrow]#3 (post-P): bal=0 amt=10',
+    ' dep[escrow]#4 (post-P): bal=0 amt=7',
+    'deposit[bobMoneyDst]#5: bal=0 amt=10',
+    'deposit[aliceStockDst]#6: bal=0 amt=7',
+    ' dep[bobMoneyDst]#5 (post-P): bal=0 amt=10',
+    ' dep[aliceStockDst]#6 (post-P): bal=0 amt=7',
+    '++ bob.invite doneP',
+    'getBalance',
+    'getBalance',
+    '++ bob.tradeWell done',
+    '++ bobP.tradeWell done:',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --bob-first without SES', async t => {
+  const dump = await main(false, 'demo/contractHost', ['bob-first']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'makeMint',
+    'makeMint',
+    '++ bob.tradeWell starting',
+    '++ bob.invite start',
+    '++ bob.invite passed check',
+    'makeEmptyPurse(bobMoneyDst)',
+    'makeEmptyPurse(bobStockSrc)',
+    'makeEmptyPurse(aliceMoneySrc)',
+    'makeEmptyPurse(aliceStockDst)',
+    'deposit[bobStockSrc]#1: bal=0 amt=7',
+    'deposit[aliceMoneySrc]#2: bal=0 amt=10',
+    ' dep[bobStockSrc]#1 (post-P): bal=0 amt=7',
+    ' dep[aliceMoneySrc]#2 (post-P): bal=0 amt=10',
+    '++ bob.invite ackP',
+    'makeEmptyPurse(escrow)',
+    'makeEmptyPurse(escrow)',
+    'deposit[escrow]#3: bal=0 amt=10',
+    'deposit[escrow]#4: bal=0 amt=7',
+    ' dep[escrow]#3 (post-P): bal=0 amt=10',
+    ' dep[escrow]#4 (post-P): bal=0 amt=7',
+    'deposit[bobMoneyDst]#5: bal=0 amt=10',
+    'deposit[aliceStockDst]#6: bal=0 amt=7',
+    ' dep[bobMoneyDst]#5 (post-P): bal=0 amt=10',
+    ' dep[aliceStockDst]#6 (post-P): bal=0 amt=7',
+    '++ bob.invite doneP',
+    'getBalance',
+    'getBalance',
+    '++ bob.tradeWell done',
+    '++ bobP.tradeWell done:',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --bob-first-lies with SES', async t => {
+  const dump = await main(true, 'demo/contractHost', ['bob-first-lies']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'makeMint',
+    'makeMint',
+    '++ bob.tradeWell starting',
+    '++ bob.invite start',
+    '++ bob.invite passed check',
+    'makeEmptyPurse(bobMoneyDst)',
+    'makeEmptyPurse(bobStockSrc)',
+    'makeEmptyPurse(aliceMoneySrc)',
+    'makeEmptyPurse(aliceStockDst)',
+    'deposit[bobStockSrc]#1: bal=0 amt=7',
+    'deposit[aliceMoneySrc]#2: bal=0 amt=10',
+    ' dep[bobStockSrc]#1 (post-P): bal=0 amt=7',
+    ' dep[aliceMoneySrc]#2 (post-P): bal=0 amt=10',
+    '++ bob.invite ackP',
+    '++ bob.tradeWell reject',
+    '++ DONE',
+  ]);
+  t.end();
+});
+
+test('run contractHost Demo --bob-first-lies without SES', async t => {
+  const dump = await main(false, 'demo/contractHost', ['bob-first-lies']);
+  t.deepEquals(dump.log, [
+    '=> setup called',
+    'makeMint',
+    'makeMint',
+    '++ bob.tradeWell starting',
+    '++ bob.invite start',
+    '++ bob.invite passed check',
+    'makeEmptyPurse(bobMoneyDst)',
+    'makeEmptyPurse(bobStockSrc)',
+    'makeEmptyPurse(aliceMoneySrc)',
+    'makeEmptyPurse(aliceStockDst)',
+    'deposit[bobStockSrc]#1: bal=0 amt=7',
+    'deposit[aliceMoneySrc]#2: bal=0 amt=10',
+    ' dep[bobStockSrc]#1 (post-P): bal=0 amt=7',
+    ' dep[aliceMoneySrc]#2 (post-P): bal=0 amt=10',
+    '++ bob.invite ackP',
+    '++ bob.tradeWell reject',
+    '++ DONE',
+  ]);
+  t.end();
+});


### PR DESCRIPTION
This PR adds tests for the demos. 

Some changes needed to be made in how the demos are run. For instance, in order to not create duplicate code, most of the machinery of `bin/vat` was moved to a new file in `demo/` called `start.js` so that it could be used by the tests as well as the command line. I also needed to add the usual logging functionality to the `contractHost` demos. Lastly, I rewrote the part of the contractHost bootstrap function that controls which demo to run. It could probably go either way easily, but when I was writing the tests, I was getting silent failures when the option I was using wasn't recognized, so I turned it into a switch statement. 