### PR TITLE
Reenable bin/vat

### DIFF
--- a/src/devices/index.js
+++ b/src/devices/index.js
@@ -1,0 +1,5 @@
+// Export all the default exports of the driver top-halves.
+export { default as buildChannel } from './channel';
+export { default as buildInbound } from './inbound';
+export { default as buildOutbox } from './outbox';
+export { default as buildSharedStringTable } from './sharedTable';


### PR DESCRIPTION
Fixes #51 

Add missing src/devices/index.js with named exports from the devices' top-halves.
