### PR TITLE
A simple Handoff service 

### DIFF
--- a/demo/handoff/bootstrap.js
+++ b/demo/handoff/bootstrap.js
@@ -1,0 +1,163 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { makeCorkboardAssayMaker } from './corkboard-assay';
+import { makeCorkboard } from './corkboard';
+import { sameStructure } from '../../collections/sameStructure';
+import { makeHandoffService } from './handoff';
+
+function build(E, log) {
+  function testCorkboardAssay() {
+    log('starting testCorkboardAssay');
+    const corkboardAssayMaker = makeCorkboardAssayMaker();
+    const assay = corkboardAssayMaker('foo');
+    if (assay.getLabel() !== 'foo') {
+      log('assay label should be "foo"');
+    }
+    if (assay.empty('corkboard') !== assay.empty('another corkboard')) {
+      log('corkboards not equal');
+    }
+
+    const fakeChannel = makeCorkboard('something');
+    const amount = assay.make(fakeChannel);
+    if (!assay.vouch(amount)) {
+      log('assay should vouch for actual amount');
+    }
+    if (assay.coerce(amount) !== amount) {
+      log('assay should coerce to itself');
+    }
+    const allegedAmount = { label: 'foo', quantity: fakeChannel };
+    if (!sameStructure(assay.coerce(allegedAmount.quantity), amount)) {
+      log(
+        `literal assay (${
+          allegedAmount.quantity
+        } should coerce to equivalent ${amount}`,
+      );
+    }
+  }
+
+  function testCorkboardAssayQuantities() {
+    log('starting testCorkboardAssayQuantities');
+    const corkboardAssayMaker = makeCorkboardAssayMaker();
+    const assay = corkboardAssayMaker('foo');
+    const fakeChannel = makeCorkboard('bar');
+    const amount = assay.make(fakeChannel);
+    if (amount !== fakeChannel) {
+      log('amount quantity should be label: "bar".');
+    }
+  }
+
+  function testCorkboardStorage() {
+    log('starting testCorkboardStorage');
+    const bb = makeCorkboard('whiteboard');
+    if (bb.getName() !== 'whiteboard') {
+      log(`bboard name should be 'whiteboard', not ${bb.getName()}`);
+    }
+  }
+
+  function testHandoffStorage(handoff) {
+    log('starting testHandoffStorage');
+    const h = makeHandoffService(handoff);
+    if (h.grab('missing') !== undefined) {
+      log('empty services should have no entries');
+    }
+    const entry = h.createEntry('rendezvous');
+    if (entry === undefined) {
+      log('should be able to create new new corkboard');
+    }
+    if (h.validate(entry) !== entry) {
+      log('expected new corkboard to validate');
+    }
+    const cork = h.grab('rendezvous');
+    if (cork === undefined) {
+      log('should be able to grab new corkboard');
+    }
+    if (cork.getName() !== 'rendezvous') {
+      log('new board name should match');
+    }
+
+    if (h.validate(cork) !== cork) {
+      log('expected corkboard to validate');
+    }
+
+    const fakeBoard = harden({
+      lookup(propertyName) {
+        return `${propertyName}: value`;
+      },
+      addEntry(_) {
+        return 1;
+      },
+      getName() {
+        return 'rendezvous';
+      },
+    });
+    try {
+      h.validate(fakeBoard);
+    } catch (error) {
+      log('expected validate to throw');
+    }
+  }
+
+  function testTwoVatHandoff(aliceMaker, bobMaker, handoffService) {
+    const aliceP = E(aliceMaker).make(handoffService);
+    const bobP = E(bobMaker).make(handoffService);
+    log('starting testHandoffStorage');
+    E(aliceP)
+      .shareSomething('schelling')
+      .then(count => {
+        if (count !== 1) {
+          log(`expecting count of 1, got ${count}`);
+        }
+        E(bobP)
+          .findSomething('schelling')
+          .then(actual => {
+            if (actual !== 42) {
+              log(`expecting coordination on 42, got ${actual}`);
+            }
+          });
+      });
+  }
+
+  const obj0 = {
+    async bootstrap(argv, vats) {
+      switch (argv[0]) {
+        case 'corkboardAssay': {
+          return testCorkboardAssay() + testCorkboardAssayQuantities();
+        }
+        case 'corkboard': {
+          return testCorkboardStorage();
+        }
+        case 'handoff': {
+          return testHandoffStorage(vats.handoff);
+        }
+        case 'twoVatHandoff': {
+          const handoffService = await E(vats.handoff).makeHandoffService();
+          const aliceMaker = await E(vats.alice).makeAliceMaker(handoffService);
+          const bobMaker = await E(vats.bob).makeBobMaker(handoffService);
+          return testTwoVatHandoff(aliceMaker, bobMaker, handoffService);
+        }
+        default: {
+          throw new Error(`unrecognized argument value ${argv[0]}`);
+        }
+      }
+    },
+  };
+  return harden(obj0);
+}
+harden(build);
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  log(`=> setup called`);
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, log),
+    helpers.vatID,
+  );
+}
+export default harden(setup);

--- a/demo/handoff/corkboard-assay.js
+++ b/demo/handoff/corkboard-assay.js
@@ -1,0 +1,132 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+import {
+  mustBeComparable,
+  mustBeSameStructure,
+  sameStructure,
+} from '../../collections/sameStructure';
+import { insist } from '../../collections/insist';
+import { makePrivateName } from '../../collections/PrivateName';
+
+// A CorkboardAssay vouches for Corkboards, which allow vats to connect to one
+// another in a lightweight way. Corkboards can not be combined or split.
+// The quantity must be a unique string. The empty value may be useful for empty
+// purses.
+function makeCorkboardAssayMaker(descriptionCoercer = d => d) {
+  function makeCorkboardAssay(label = 'generic') {
+    mustBeComparable(label);
+
+    const brand = makePrivateName();
+
+    const emptyAmount = harden({ label, quantity: null });
+    brand.init(emptyAmount);
+
+    const assay = harden({
+      getLabel() {
+        return label;
+      },
+
+      make(optDescription) {
+        if (optDescription === null) {
+          return emptyAmount;
+        }
+        insist(!!optDescription)`\
+Corkboard optDescription must be either null or truthy ${optDescription}`;
+        mustBeComparable(optDescription);
+
+        const description = descriptionCoercer(optDescription);
+        insist(!!description)`\
+Corkboard description must be truthy ${description}`;
+        mustBeComparable(description);
+
+        const amount = harden(description);
+        brand.init(amount);
+        return amount;
+      },
+
+      vouch(amount) {
+        insist(brand.has(amount))`\
+Unrecognized amount: ${amount}`;
+        return amount;
+      },
+
+      coerce(allegedMetaAmount) {
+        if (brand.has(allegedMetaAmount)) {
+          return allegedMetaAmount;
+        }
+        const { label: allegedLabel, quantity } = allegedMetaAmount;
+        mustBeSameStructure(label, allegedLabel, 'Unrecognized label');
+        if (brand.has(quantity)) {
+          return brand.get(quantity);
+        }
+        return assay.make(quantity);
+      },
+
+      quantity(amount) {
+        return assay.vouch(amount).quantity;
+      },
+
+      empty() {
+        return emptyAmount;
+      },
+
+      isEmpty(amount) {
+        return assay.quantity(amount) === null;
+      },
+
+      includes(leftAmount, rightAmount) {
+        const leftQuant = assay.quantity(leftAmount);
+        const rightQuant = assay.quantity(rightAmount);
+        if (rightQuant === null) {
+          return true;
+        }
+        return leftQuant === rightQuant;
+      },
+
+      with(leftAmount, rightAmount) {
+        const leftQuant = assay.quantity(leftAmount);
+        const rightQuant = assay.quantity(rightAmount);
+        if (leftQuant === null) {
+          return rightAmount;
+        }
+        if (rightQuant === null) {
+          return leftAmount;
+        }
+        if (sameStructure(leftQuant, rightQuant)) {
+          // The "throw" is useless since insist(false) will unconditionally
+          // throw anyway. Rather, it informs IDEs of this control flow.
+          throw insist(false)`\
+Even identical non-empty uni amounts cannot be added together ${leftAmount}`;
+        } else {
+          // The "throw" is useless since insist(false) will unconditionally
+          // throw anyway. Rather, it informs IDEs of this control flow.
+          throw insist(false)`\
+Cannot combine different uni descriptions ${leftAmount} vs ${rightAmount}`;
+        }
+      },
+
+      without(leftAmount, rightAmount) {
+        const leftQuant = assay.quantity(leftAmount);
+        const rightQuant = assay.quantity(rightAmount);
+        if (rightQuant === null) {
+          return leftAmount;
+        }
+        insist(leftQuant !== null)`\
+Empty left does not include ${rightAmount}`;
+
+        mustBeSameStructure(
+          leftQuant,
+          rightQuant,
+          'Cannot subtract Corkboard descriptions',
+        );
+        return emptyAmount;
+      },
+    });
+    return assay;
+  }
+  return harden(makeCorkboardAssay);
+}
+harden(makeCorkboardAssayMaker);
+
+export { makeCorkboardAssayMaker };

--- a/demo/handoff/corkboard.js
+++ b/demo/handoff/corkboard.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+// Allows multiple parties to store values for retrieval by others.
+function makeCorkboard(name) {
+  const namedEntries = new Map();
+  const orderedEntries = [];
+
+  return harden({
+    lookup(propertyName) {
+      if (!namedEntries.has(propertyName)) {
+        return undefined;
+      }
+      return namedEntries.get(propertyName)[0];
+    },
+    addEntry(key, value) {
+      if (namedEntries.has(key)) {
+        throw new Error(`Corkboard ${name} already has an entry for ${key}.`);
+      }
+      orderedEntries.push([key, value]);
+      namedEntries.set(key, [value, orderedEntries.length]);
+      return orderedEntries.length;
+    },
+    getName() {
+      return name;
+    },
+    // TODO(hibbert) retrieve by numbered position
+  });
+}
+harden(makeCorkboard());
+
+export { makeCorkboard };

--- a/demo/handoff/handoff.js
+++ b/demo/handoff/handoff.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { makeCorkboardAssayMaker } from './corkboard-assay';
+import { makeCorkboard } from './corkboard';
+
+function makeHandoffService() {
+  // I'd have used PrivateNames, but they want objects (not Strings) as Keys.
+  const boards = new Map();
+
+  const corkboardAssayMaker = makeCorkboardAssayMaker();
+  const corkboardAssay = corkboardAssayMaker('root');
+
+  const handoffService = harden({
+    // retrieve and remove from the map.
+    grab(key) {
+      if (!boards.has(key)) {
+        return undefined;
+      }
+      const result = boards.get(key);
+      // these are single-use entries.
+      boards.delete(key);
+      return result;
+    },
+    createEntry(preferredName) {
+      if (boards.has(preferredName)) {
+        throw new Error(`Entry already exists: ${preferredName}`);
+      }
+      const corkBoard = makeCorkboard(preferredName);
+      boards.set(preferredName, corkBoard);
+      corkboardAssay.make(corkBoard);
+      return corkBoard;
+    },
+    validate(allegedBoard) {
+      return corkboardAssay.vouch(allegedBoard);
+    },
+    // We don't need remove, since grab can be used for that.
+  });
+
+  return handoffService;
+}
+
+export { makeHandoffService };

--- a/demo/handoff/vat-alice.js
+++ b/demo/handoff/vat-alice.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+function makeAliceMaker(E, _host, _log) {
+  return harden({
+    make(handoffServiceP) {
+      const alice = harden({
+        shareSomething(someKey) {
+          return E(handoffServiceP)
+            .createEntry(someKey)
+            .then(board => E(board).addEntry(someKey, 42));
+        },
+      });
+      return alice;
+    },
+  });
+}
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  return helpers.makeLiveSlots(syscall, state, E =>
+    harden({
+      makeAliceMaker(host) {
+        return harden(makeAliceMaker(E, host, log));
+      },
+    }),
+  );
+}
+export default harden(setup);

--- a/demo/handoff/vat-bob.js
+++ b/demo/handoff/vat-bob.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+function makeBobMaker(E, _host, _log) {
+  return harden({
+    make(handoffServiceP) {
+      const bob = harden({
+        findSomething(key) {
+          const boardP = E(handoffServiceP).grab(key);
+          return E(handoffServiceP)
+            .vouch(boardP)
+            .then(E(boardP).lookup(key));
+        },
+      });
+      return bob;
+    },
+  });
+}
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  return helpers.makeLiveSlots(syscall, state, E =>
+    harden({
+      makeBobMaker(host) {
+        return harden(makeBobMaker(E, host, log));
+      },
+    }),
+  );
+}
+export default harden(setup);

--- a/demo/handoff/vat-handoff.js
+++ b/demo/handoff/vat-handoff.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { makeHandoffService } from './handoff';
+
+function build(_E, _log) {
+  return harden({ makeHandoffService });
+}
+harden(build);
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, log),
+    helpers.vatID,
+  );
+}
+export default harden(setup);

--- a/test/test-demos.js
+++ b/test/test-demos.js
@@ -229,3 +229,49 @@ test('run contractHost Demo --covered-call-sale without SES', async t => {
   t.deepEquals(dump.log, contractCoveredCallSaleGolden);
   t.end();
 });
+
+const corkboardAssaysGolden = [
+  '=> setup called',
+  'starting testCorkboardAssay',
+  'starting testCorkboardAssayQuantities',
+];
+
+test('run handoff Demo --corkboard assays', async t => {
+  const dump = await main(false, 'demo/handoff', ['corkboardAssay']);
+  t.deepEquals(dump.log, corkboardAssaysGolden);
+  t.end();
+});
+
+const corkboardContentsGolden = [
+  '=> setup called',
+  'starting testCorkboardStorage',
+];
+
+test('run handoff Demo --corkboard contents', async t => {
+  const dump = await main(false, 'demo/handoff', ['corkboard']);
+  t.deepEquals(dump.log, corkboardContentsGolden);
+  t.end();
+});
+
+const handoffTestGolden = [
+  '=> setup called',
+  'starting testHandoffStorage',
+  'expected validate to throw',
+];
+
+test('run handoff Demo --handoff service', async t => {
+  const dump = await main(false, 'demo/handoff', ['handoff']);
+  t.deepEquals(dump.log, handoffTestGolden);
+  t.end();
+});
+
+const twoPartyHandoffGolden = [
+  '=> setup called',
+  'starting testHandoffStorage',
+];
+
+test('run handoff Demo --Two Party handoff', async t => {
+  const dump = await main(false, 'demo/handoff', ['twoVatHandoff']);
+  t.deepEquals(dump.log, twoPartyHandoffGolden);
+  t.end();
+});

--- a/test/test-demos.js
+++ b/test/test-demos.js
@@ -242,6 +242,12 @@ test('run handoff Demo --corkboard assays', async t => {
   t.end();
 });
 
+test('run handoff Demo --corkboard assays', async t => {
+  const dump = await main(true, 'demo/handoff', ['corkboardAssay']);
+  t.deepEquals(dump.log, corkboardAssaysGolden);
+  t.end();
+});
+
 const corkboardContentsGolden = [
   '=> setup called',
   'starting testCorkboardStorage',
@@ -249,6 +255,12 @@ const corkboardContentsGolden = [
 
 test('run handoff Demo --corkboard contents', async t => {
   const dump = await main(false, 'demo/handoff', ['corkboard']);
+  t.deepEquals(dump.log, corkboardContentsGolden);
+  t.end();
+});
+
+test('run handoff Demo --corkboard contents', async t => {
+  const dump = await main(true, 'demo/handoff', ['corkboard']);
   t.deepEquals(dump.log, corkboardContentsGolden);
   t.end();
 });
@@ -265,6 +277,12 @@ test('run handoff Demo --handoff service', async t => {
   t.end();
 });
 
+test('run handoff Demo --handoff service', async t => {
+  const dump = await main(true, 'demo/handoff', ['handoff']);
+  t.deepEquals(dump.log, handoffTestGolden);
+  t.end();
+});
+
 const twoPartyHandoffGolden = [
   '=> setup called',
   'starting testHandoffStorage',
@@ -272,6 +290,12 @@ const twoPartyHandoffGolden = [
 
 test('run handoff Demo --Two Party handoff', async t => {
   const dump = await main(false, 'demo/handoff', ['twoVatHandoff']);
+  t.deepEquals(dump.log, twoPartyHandoffGolden);
+  t.end();
+});
+
+test('run handoff Demo --Two Party handoff', async t => {
+  const dump = await main(true, 'demo/handoff', ['twoVatHandoff']);
   t.deepEquals(dump.log, twoPartyHandoffGolden);
   t.end();
 });


### PR DESCRIPTION
A simple Handoff service that can be provided to vats to allow them to set up channels ('corkboards') to share pointers with others.

There's more functionality that could be added, but it passes a three-vat test, enabling Alice to pass a value to Bob.

Next step if we like the current state is to add this to everyone's home list and validate that it works in that environment.