### PR TITLE
Change CLists to allow mapping a single kernelSlot to multiple machines

### DIFF
--- a/src/kernel/commsSlots/outbound/mapOutbound.js
+++ b/src/kernel/commsSlots/outbound/mapOutbound.js
@@ -2,6 +2,7 @@ function makeMapOutbound(syscall, state) {
   function mapOutbound(otherMachineName, kernelToMeSlot) {
     const outgoingWireMessageObj = state.clists.mapKernelSlotToOutgoingWireMessage(
       kernelToMeSlot,
+      otherMachineName,
     ); //  otherMachineName, direction, meToYouSlot
     if (outgoingWireMessageObj === undefined) {
       // this is something that we have on this machine, and we want
@@ -104,12 +105,13 @@ function makeMapOutbound(syscall, state) {
     }
     const outgoingWireMessage = state.clists.mapKernelSlotToOutgoingWireMessage(
       kernelToMeSlot,
+      otherMachineName,
     );
     return outgoingWireMessage.meToYouSlot;
   }
 
   function mapOutboundTarget(kernelToMeSlot) {
-    const outgoingWireMessageObj = state.clists.mapKernelSlotToOutgoingWireMessage(
+    const outgoingWireMessageList = state.clists.mapKernelSlotToOutgoingWireMessageList(
       kernelToMeSlot,
     ); //  otherMachineName, direction, meToYouSlot
     // we will need to know what machine to send it to, just from the
@@ -117,12 +119,12 @@ function makeMapOutbound(syscall, state) {
 
     // we also do not allocate a new id, if we can't find it, it's an
     // error.
-    if (!outgoingWireMessageObj) {
+    if (!outgoingWireMessageList) {
       throw new Error(
         `targetSlot ${JSON.stringify(kernelToMeSlot)} is not recognized`,
       );
     }
-    return outgoingWireMessageObj;
+    return outgoingWireMessageList;
   }
 
   return {

--- a/test/commsSlots/commsController/test-addEgress.js
+++ b/test/commsSlots/commsController/test-addEgress.js
@@ -53,7 +53,7 @@ test('handleCommsController addEgress', t => {
   );
   const {
     meToYouSlot: actualMeToYouSlot,
-  } = state.clists.mapKernelSlotToOutgoingWireMessage(caps[0]);
+  } = state.clists.mapKernelSlotToOutgoingWireMessage(caps[0], sender);
   t.deepEqual(kernelToMeSlot, caps[0]); // actual, expected
   t.deepEqual(actualMeToYouSlot, meToYouSlot);
   t.end();

--- a/test/commsSlots/commsController/test-addIngress.js
+++ b/test/commsSlots/commsController/test-addIngress.js
@@ -58,10 +58,13 @@ test('handleCommsController addIngress', t => {
   );
   const {
     meToYouSlot: actualMeToYouSlot,
-  } = state.clists.mapKernelSlotToOutgoingWireMessage({
-    type: 'export',
-    id: 1,
-  });
+  } = state.clists.mapKernelSlotToOutgoingWireMessage(
+    {
+      type: 'export',
+      id: 1,
+    },
+    sender,
+  );
   t.deepEqual(kernelToMeSlot, { type: 'export', id: 1 }); // actual, expected
   t.deepEqual(actualMeToYouSlot, expectedMeToYouSlot);
   t.end();
@@ -114,10 +117,13 @@ test('handleCommsController addIngress twice', t => {
   );
   const {
     meToYouSlot: actualMeToYouSlot,
-  } = state.clists.mapKernelSlotToOutgoingWireMessage({
-    type: 'export',
-    id: 1,
-  });
+  } = state.clists.mapKernelSlotToOutgoingWireMessage(
+    {
+      type: 'export',
+      id: 1,
+    },
+    sender,
+  );
   t.deepEqual(actualKernelToMeSlot, { type: 'export', id: 1 }); // actual, expected
   t.deepEqual(actualMeToYouSlot, { type: 'your-egress', id: index });
 
@@ -151,10 +157,13 @@ test('handleCommsController addIngress twice', t => {
   );
   const {
     meToYouSlot: actualMeToYouSlot2,
-  } = state.clists.mapKernelSlotToOutgoingWireMessage({
-    type: 'export',
-    id: 2,
-  });
+  } = state.clists.mapKernelSlotToOutgoingWireMessage(
+    {
+      type: 'export',
+      id: 2,
+    },
+    sender2,
+  );
   t.deepEqual(actualKernelToMeSlot2, { type: 'export', id: 2 }); // actual, expected
   t.deepEqual(actualMeToYouSlot2, { type: 'your-egress', id: index2 });
   t.end();
@@ -205,10 +214,13 @@ test('handleCommsController addIngress same again', t => {
   );
   const {
     meToYouSlot: actualMeToYouSlot,
-  } = state.clists.mapKernelSlotToOutgoingWireMessage({
-    type: 'export',
-    id: 1,
-  });
+  } = state.clists.mapKernelSlotToOutgoingWireMessage(
+    {
+      type: 'export',
+      id: 1,
+    },
+    sender,
+  );
   t.deepEqual(actualKernelToMeSlot, { type: 'export', id: 1 }); // actual, expected
   t.deepEqual(actualMeToYouSlot, { type: 'your-egress', id: index });
 
@@ -242,10 +254,13 @@ test('handleCommsController addIngress same again', t => {
   );
   const {
     meToYouSlot: actualMeToYouSlot2,
-  } = state.clists.mapKernelSlotToOutgoingWireMessage({
-    type: 'export',
-    id: 1,
-  });
+  } = state.clists.mapKernelSlotToOutgoingWireMessage(
+    {
+      type: 'export',
+      id: 1,
+    },
+    sender,
+  );
   t.deepEqual(actualKernelToMeSlot2, { type: 'export', id: 1 }); // actual, expected
   t.deepEqual(actualMeToYouSlot2, { type: 'your-egress', id: index });
 

--- a/test/commsSlots/makeCommsSlots/test-deliver.js
+++ b/test/commsSlots/makeCommsSlots/test-deliver.js
@@ -140,10 +140,13 @@ test('makeCommsSlots deliver to egress', t => {
   calls.shift();
 
   t.deepEqual(
-    state.clists.mapKernelSlotToOutgoingWireMessage({
-      type: 'promise',
-      id: 66,
-    }),
+    state.clists.mapKernelSlotToOutgoingWireMessage(
+      {
+        type: 'promise',
+        id: 66,
+      },
+      'bot',
+    ),
     { otherMachineName: 'bot', meToYouSlot: { type: 'your-promise', id: 71 } },
   );
   t.end();

--- a/test/commsSlots/state/test-makeCLists.js
+++ b/test/commsSlots/state/test-makeCLists.js
@@ -14,7 +14,49 @@ test('Clists add and get', t => {
   t.deepEqual(actualKernelToMeSlot, kernelToMeSlot);
   const {
     meToYouSlot: actualMeToYouSlot,
-  } = clists.mapKernelSlotToOutgoingWireMessage(kernelToMeSlot);
+  } = clists.mapKernelSlotToOutgoingWireMessage(kernelToMeSlot, 'machine0');
   t.equal(actualMeToYouSlot, meToYouSlot);
+  t.end();
+});
+
+test('Add same object from multiple machines', t => {
+  const clists = makeCLists();
+  const kernelToMeSlot = { type: 'export', id: 1 };
+  const youToMeSlot0 = { type: 'your-ingress', id: 102 };
+  const meToYouSlot0 = clists.changePerspective(youToMeSlot0);
+
+  const youToMeSlot3 = { type: 'your-ingress', id: 593 };
+  const meToYouSlot3 = clists.changePerspective(youToMeSlot3);
+
+  clists.add('machine0', kernelToMeSlot, youToMeSlot0, meToYouSlot0);
+  clists.add('machine3', kernelToMeSlot, youToMeSlot3, meToYouSlot3);
+  const actualKernelToMeSlot0 = clists.mapIncomingWireMessageToKernelSlot(
+    'machine0',
+    youToMeSlot0,
+  );
+  const actualKernelToMeSlot3 = clists.mapIncomingWireMessageToKernelSlot(
+    'machine3',
+    youToMeSlot3,
+  );
+  t.deepEqual(actualKernelToMeSlot0, actualKernelToMeSlot3);
+
+  const outgoingWireMessage0 = clists.mapKernelSlotToOutgoingWireMessage(
+    kernelToMeSlot,
+    'machine0',
+  );
+  const outgoingWireMessage3 = clists.mapKernelSlotToOutgoingWireMessage(
+    kernelToMeSlot,
+    'machine3',
+  );
+  t.deepEqual(outgoingWireMessage0.meToYouSlot, meToYouSlot0);
+  t.notDeepEqual(
+    outgoingWireMessage3.meToYouSlot,
+    outgoingWireMessage0.meToYouSlot,
+  );
+
+  const messageList = clists.mapKernelSlotToOutgoingWireMessageList(
+    kernelToMeSlot,
+  );
+  t.deepEqual(messageList, [outgoingWireMessage0, outgoingWireMessage3]);
   t.end();
 });


### PR DESCRIPTION
Previously, the commsSlots cLists assumed that a kernelSlot would map to a single machine. This PR adds a layer of flexibility such that a kernelSlot can map to multiple machines. 

Changes in CLists.js:
* `checkIfAlreadyExists` is changed to only error if both the kernelSlot and the outgoingWireMessage to be stored are the same (i.e. same kernelSlot for same other machine). 
* `mapKernelSlotToOutgoingWireMessage` takes in an additional parameter - `otherMachineName`
* a new function, `mapKernelSlotToOutgoingWireMessageList` is used when we don't yet know the machine to send a message to, and we only know the kernelToMeSlot this returns a list of outgoingWireMessages
* The `add` function adds the `outgoingWireMessageObj` to a map keyed on `otherMachineName`. This is what enables the lookup for `mapKernelSlotToOutgoingWireMessage` and the creation of the list in `mapKernelSlotToOutgoingWireMessageList`

Changes elsewhere:
* mapOutbound.js was changed to use `mapKernelSlotToOutgoingWireMessageList` if we don't know the otherMachineName and `mapKernelSlotToOutgoingWireMessage` when we do.
* the functions in commsSlots.js had to be uniformly changed to do their usual functionality, but instead, over an array of outgoingWireMessages to be sent, rather than assuming there is only one. 
* misc changes to tests


