### PR TITLE
Fix ertp-30

### DIFF
--- a/src/kernel/commsSlots/commsSlots.js
+++ b/src/kernel/commsSlots/commsSlots.js
@@ -37,7 +37,13 @@ export default function makeCommsSlots(syscall, _state, helpers) {
 
   const dispatch = harden({
     // eslint-disable-next-line consistent-return
-    deliver(facetid, method, argsStr, kernelToMeSlots, resolverID) {
+    deliver(
+      facetid,
+      method,
+      argsStr,
+      kernelToMeSlots,
+      { promiseID, resolverID },
+    ) {
       const kernelToMeSlotTarget = { type: 'export', id: facetid };
       csdebug(
         `cs[${vatID}].dispatch.deliver ${facetid}.${method} -> ${resolverID}`,
@@ -114,10 +120,14 @@ export default function makeCommsSlots(syscall, _state, helpers) {
 
         // TODO: resolverID might be empty if the local vat did
         // syscall.sendOnly, in which case we should leave resultSlot empty too
-        const resultSlot = mapOutbound(otherMachineName, {
-          type: 'resolver',
-          id: resolverID,
-        });
+        const resultSlot = mapOutbound(
+          otherMachineName,
+          {
+            type: 'resolver',
+            id: resolverID,
+          },
+          promiseID,
+        );
 
         const message = JSON.stringify({
           target: meToYouTargetSlot,

--- a/src/kernel/commsSlots/outbound/mapOutbound.js
+++ b/src/kernel/commsSlots/outbound/mapOutbound.js
@@ -1,5 +1,5 @@
 function makeMapOutbound(syscall, state) {
-  function mapOutbound(otherMachineName, kernelToMeSlot) {
+  function mapOutbound(otherMachineName, kernelToMeSlot, promiseID) {
     const outgoingWireMessageObj = state.clists.mapKernelSlotToOutgoingWireMessage(
       kernelToMeSlot,
       otherMachineName,
@@ -73,20 +73,15 @@ function makeMapOutbound(syscall, state) {
             id,
           };
 
-          // kernelToMeSlot can't be type resolver
-          // overwrite it for now
-          const kernelToMeSlotID = kernelToMeSlot.id;
-          const promise = {
-            type: 'promise',
-            id: kernelToMeSlotID,
-          };
-          const resolver = {
-            type: 'resolver',
-            id: kernelToMeSlotID,
-          };
-          kernelToMeSlot = promise;
+          const promise = { type: 'promise', id: promiseID };
+          const resolver = { type: 'resolver', id: kernelToMeSlot.id };
 
           state.promiseResolverPairs.add(promise, resolver);
+
+          // set kernelToMeSlot to the promise
+          // TODO: why is this required?
+
+          kernelToMeSlot = promise;
 
           break;
         }

--- a/src/kernel/liveSlots.js
+++ b/src/kernel/liveSlots.js
@@ -335,7 +335,7 @@ function build(syscall, _state, makeRoot, forVatID) {
     return pr;
   }
 
-  function deliver(facetid, method, argsbytes, caps, resolverID) {
+  function deliver(facetid, method, argsbytes, caps, { resolverID }) {
     lsdebug(
       `ls[${forVatID}].dispatch.deliver ${facetid}.${method} -> ${resolverID}`,
     );

--- a/src/kernel/vatManager.js
+++ b/src/kernel/vatManager.js
@@ -495,6 +495,10 @@ export default function makeVatManager(
         msg.kernelResolverID &&
         mapKernelSlotToVatSlot({ type: 'resolver', id: msg.kernelResolverID })
           .id;
+      const promiseID =
+        msg.kernelResolverID &&
+        mapKernelSlotToVatSlot({ type: 'promise', id: msg.kernelResolverID })
+          .id;
       return doProcess(
         [
           'deliver',
@@ -502,7 +506,7 @@ export default function makeVatManager(
           msg.method,
           msg.argsString,
           inputSlots,
-          resolverID,
+          harden({ promiseID, resolverID }),
         ],
         `vat[${vatID}][${target.id}].${msg.method} dispatch failed`,
       );

--- a/test/commsSlots/makeCommsSlots/test-deliver.js
+++ b/test/commsSlots/makeCommsSlots/test-deliver.js
@@ -28,7 +28,7 @@ test('makeCommsSlots deliver to commsController (facetid 0)', t => {
     'init',
     '{"args":[{"@qclass":"slot","index":0}]}',
     [vatTP],
-    30,
+    { resolverID: 30, promiseID: 20 },
   );
 
   t.deepEqual(calls[0], [
@@ -81,7 +81,7 @@ test('makeCommsSlots deliver to egress', t => {
     'init',
     '{"args":[{"@qclass":"slot","index":0}]}',
     [vatTP],
-    30,
+    { resolverID: 30, promiseID: 20 },
   );
   t.equal(calls[0][0], 'send');
   calls.shift();
@@ -102,7 +102,7 @@ test('makeCommsSlots deliver to egress', t => {
     'addEgress',
     '{"args":["bot", 70, {"@qclass":"slot","index":0}]}',
     [{ type: 'import', id: 55 }],
-    31,
+    { resolverID: 31, promiseID: 21 },
   );
   t.deepEqual(calls, [['fulfillToData', [31, UNDEFINED, []]]]);
   calls.shift();
@@ -123,7 +123,7 @@ test('makeCommsSlots deliver to egress', t => {
     'inbound',
     JSON.stringify(inboundArgs),
     [],
-    undefined,
+    { resolverID: undefined, promiseID: undefined },
   );
   // that ought to cause a syscall.send to import:55
   t.deepEqual(calls[0], [
@@ -164,7 +164,10 @@ test('makeCommsSlots deliver facetid is unexpected', t => {
   const commsSlots = makeCommsSlots(mockSyscall, {}, helpers);
 
   t.throws(() => {
-    commsSlots.deliver(99, 'init', '{"args":["bot","botSigningKey"]}', [], 30);
+    commsSlots.deliver(99, 'init', '{"args":["bot","botSigningKey"]}', [], {
+      resolverID: 30,
+      promiseID: 20,
+    });
   }, "{[Error: unknown facetid] message: 'unknown facetid' }");
   t.equal(calls.length, 0);
   // TODO: init() really ought to notifyReject() upon error, not leave the
@@ -203,7 +206,7 @@ test('makeCommsSlots deliver to ingress', t => {
     'init',
     '{"args":[{"@qclass":"slot","index":0}]}',
     [vatTP],
-    30,
+    { resolverID: 30, promiseID: 20 },
   );
   t.equal(calls[0][0], 'send');
   calls.shift();
@@ -216,12 +219,15 @@ test('makeCommsSlots deliver to ingress', t => {
     'addIngress',
     '{"args":["bot", {"@qclass":"slot","index":0}]}',
     [{ type: 'your-ingress', id: 0 }],
-    31,
+    { resolverID: 31, promiseID: 21 },
   );
   t.deepEqual(calls[0], ['fulfillToPresence', [31, { type: 'export', id: 2 }]]);
   calls.shift();
 
-  commsSlots.deliver(2, 'encourageMe', '{"args":["me"]}', [], 32);
+  commsSlots.deliver(2, 'encourageMe', '{"args":["me"]}', [], {
+    resolverID: 32,
+    promiseID: 22,
+  });
   t.equal(calls[0][0], 'send');
   const args = calls[0][1];
   calls.shift();

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -171,7 +171,8 @@ async function bootstrapExport(t, withSES) {
     ['_bootstrap', 'import', 11, 'export', 'right', 0],
     ['_bootstrap', 'promise', 20, 40],
     ['left', 'import', 10, 'export', 'right', 0],
-    ['left', 'promise', 20, 41],
+    ['left', 'promise', 20, 40],
+    ['left', 'promise', 21, 41],
     ['left', 'resolver', 30, 40],
   ]);
   t.deepEqual(c.dump().runQueue, [
@@ -209,8 +210,10 @@ async function bootstrapExport(t, withSES) {
     ['_bootstrap', 'import', 11, 'export', 'right', 0],
     ['_bootstrap', 'promise', 20, 40],
     ['left', 'import', 10, 'export', 'right', 0],
-    ['left', 'promise', 20, 41],
+    ['left', 'promise', 20, 40],
+    ['left', 'promise', 21, 41],
     ['left', 'resolver', 30, 40],
+    ['right', 'promise', 20, 41],
     ['right', 'resolver', 30, 41],
   ]);
   t.deepEqual(c.dump().runQueue, [
@@ -234,8 +237,10 @@ async function bootstrapExport(t, withSES) {
     ['_bootstrap', 'import', 11, 'export', 'right', 0],
     ['_bootstrap', 'promise', 20, 40],
     ['left', 'import', 10, 'export', 'right', 0],
-    ['left', 'promise', 20, 41],
+    ['left', 'promise', 20, 40],
+    ['left', 'promise', 21, 41],
     ['left', 'resolver', 30, 40],
+    ['right', 'promise', 20, 41],
     ['right', 'resolver', 30, 41],
   ]);
   t.deepEqual(c.dump().runQueue, [
@@ -258,8 +263,10 @@ async function bootstrapExport(t, withSES) {
     ['_bootstrap', 'import', 11, 'export', 'right', 0],
     ['_bootstrap', 'promise', 20, 40],
     ['left', 'import', 10, 'export', 'right', 0],
-    ['left', 'promise', 20, 41],
+    ['left', 'promise', 20, 40],
+    ['left', 'promise', 21, 41],
     ['left', 'resolver', 30, 40],
+    ['right', 'promise', 20, 41],
     ['right', 'resolver', 30, 41],
   ]);
   t.deepEqual(c.dump().runQueue, []);

--- a/test/test-kernel.js
+++ b/test/test-kernel.js
@@ -280,6 +280,7 @@ test('outbound call', async t => {
     ['vat1', 'import', v1tovat25.id, 'export', 'vat2', 5],
     ['vat1', 'promise', 20, 40],
     ['vat2', 'import', 10, 'export', 'vat1', 7],
+    ['vat2', 'promise', 20, 40],
     ['vat2', 'resolver', 30, 40],
   ]);
 
@@ -418,6 +419,7 @@ test('three-party', async t => {
     ['vatA', 'promise', 20, 41],
     ['vatB', 'import', 10, 'export', 'vatC', 6],
     ['vatB', 'promise', bp.promiseID, 40],
+    ['vatB', 'promise', 21, 41],
     ['vatB', 'resolver', 30, 40],
     ['vatB', 'resolver', 31, 41],
   ]);
@@ -584,6 +586,7 @@ test('transfer promise', async t => {
     ['vatA', 'resolver', 31, 41], // pr2
     ['vatB', 'import', 10, 'export', 'vatA', 6],
     ['vatB', 'promise', 20, 41],
+    ['vatB', 'promise', 21, 42],
     ['vatB', 'resolver', 30, 42], // resolver for answer of foo1()
   ]);
 
@@ -604,6 +607,8 @@ test('transfer promise', async t => {
     ['vatA', 'resolver', 31, 41], // pr2
     ['vatB', 'import', 10, 'export', 'vatA', 6],
     ['vatB', 'promise', 20, 41],
+    ['vatB', 'promise', 21, 42],
+    ['vatB', 'promise', 22, 43],
     ['vatB', 'resolver', 30, 42], // resolver for answer of foo1()
     ['vatB', 'resolver', 31, 43], // resolver for answer of foo2()
   ]);
@@ -657,12 +662,15 @@ test('transfer promise', async t => {
     ['vatA', 'promise', 21, 41], // pr2
     ['vatA', 'promise', 22, 42], // promise for answer of foo1()
     ['vatA', 'promise', 23, 43], // promise for answer of foo2()
+    ['vatA', 'promise', 24, 44],
     ['vatA', 'resolver', 30, 40], // pr1
     ['vatA', 'resolver', 31, 41], // pr2
     ['vatA', 'resolver', 32, 44], // resolver for answer of foo3()
     ['vatB', 'import', 10, 'export', 'vatA', 6],
     ['vatB', 'promise', 20, 41],
-    ['vatB', 'promise', 21, 44], // promise for answer of foo3()
+    ['vatB', 'promise', 21, 42], // promise for answer of foo3()
+    ['vatB', 'promise', 22, 43],
+    ['vatB', 'promise', 23, 44],
     ['vatB', 'resolver', 30, 42], // resolver for answer of foo1()
     ['vatB', 'resolver', 31, 43], // resolver for answer of foo2()
   ]);
@@ -731,14 +739,18 @@ test('transfer promise', async t => {
     ['vatA', 'promise', 21, 41], // pr2
     ['vatA', 'promise', 22, 42], // promise for answer of foo1()
     ['vatA', 'promise', 23, 43], // promise for answer of foo2()
+    ['vatA', 'promise', 24, 44],
+    ['vatA', 'promise', 25, 45],
     ['vatA', 'resolver', 30, 40], // pr1
     ['vatA', 'resolver', 31, 41], // pr2
     ['vatA', 'resolver', 32, 44], // resolver for answer of foo3()
     ['vatA', 'resolver', 33, 45], // resolver for answer of foo4()
     ['vatB', 'import', 10, 'export', 'vatA', 6],
     ['vatB', 'promise', 20, 41],
-    ['vatB', 'promise', 21, 44], // promise for answer of foo3()
-    ['vatB', 'promise', 22, 45], // promise for answer of foo4()
+    ['vatB', 'promise', 21, 42],
+    ['vatB', 'promise', 22, 43],
+    ['vatB', 'promise', 23, 44], // promise for answer of foo3()
+    ['vatB', 'promise', 24, 45], // promise for answer of foo4()
     ['vatB', 'resolver', 30, 42], // resolver for answer of foo1()
     ['vatB', 'resolver', 31, 43], // resolver for answer of foo2()
   ]);
@@ -1102,7 +1114,7 @@ test('transcript', async t => {
       'store',
       'args string',
       [{ id: 1, type: 'export' }, { id: 10, type: 'import' }],
-      null,
+      { promiseID: null, resolverID: null },
     ],
     syscalls: [
       {


### PR DESCRIPTION
I figured out what was happening in [ERTP-30](https://github.com/Agoric/ERTP/issues/30). 

In dispatch.deliver in both [liveSlots](https://github.com/Agoric/SwingSet/blob/a191a0cb5334dc591b96ead7821ba92200f27ad7/src/kernel/liveSlots.js#L338) and [commsSlots](https://github.com/Agoric/SwingSet/blob/a191a0cb5334dc591b96ead7821ba92200f27ad7/src/kernel/commsSlots/commsSlots.js#L40), we pass in a resolverID that represents the result of that call. 

However, this should really be a promise/resolver pair, because at various other points, we need to be able to reference either the resolver or its paired promise. We need to be able to reference either so that we can use the same code as for all of our other promises/resolvers, such that the result is not a special case. 

Lacking the promise part of the result pair, the code in [mapOutbound.js line 79](https://github.com/Agoric/SwingSet/blob/a191a0cb5334dc591b96ead7821ba92200f27ad7/src/kernel/commsSlots/outbound/mapOutbound.js#L79) was creating an object of type promise and id equal to the resolverID. But, this collided with another promise id produced later down the line. 

To give an example, a call to tapFaucet had a resolverID of 34. We stored that in our cList representations as resolver:34 and promise:34 because we have to create a promiseID since we were only given the resolverID. Then later, we get an argument slot that is also promise:34. When we look it up in our tables, we find the data that was previously stored, but this is a mistake, because this second promise is unrelated to resolver:34. 

The solution is to pass the promise/resolver pair to `dispatch.deliver` rather than just the resolverID. The interface follows the `syscall.createPromise()` interface, which returns an object like: `{ resolverID: 30, promiseID: 20}`. This allows us to use the promise that is already associated with the resolver. 

There may be even better fixes that come from more thorough overhauls of SwingSet, but this will robustly solve our problem for now. 

