### PR TITLE
Fix ertp-30

### DIFF
--- a/src/kernel/commsSlots/commsSlots.js
+++ b/src/kernel/commsSlots/commsSlots.js
@@ -43,7 +43,8 @@ export default function makeCommsSlots(syscall, _state, helpers) {
     deliver(facetid, method, argsStr, kernelToMeSlots, resolver) {
       const kernelToMeSlotTarget = { type: 'export', id: facetid };
       csdebug(
-        `cs[${vatID}].dispatch.deliver ${facetid}.${method} -> ${resolver && resolver.id}`,
+        `cs[${vatID}].dispatch.deliver ${facetid}.${method} -> ${resolver &&
+          resolver.id}`,
       );
 
       // CASE 1: we are hitting the initial object (0)

--- a/src/kernel/commsSlots/inbound/mapInbound.js
+++ b/src/kernel/commsSlots/inbound/mapInbound.js
@@ -69,7 +69,7 @@ function makeMapInbound(syscall, state, senderID) {
   }
 
   function mapInboundResolver(youToMeSlot) {
-    // we store the promise in the clist, but we need to get the resolver
+    // sometimes the resolver is stored (the resultSlot case), sometimes the promise is stored
     const kernelToMeSlot = state.clists.mapIncomingWireMessageToKernelSlot(
       senderID,
       youToMeSlot,

--- a/src/kernel/liveSlots.js
+++ b/src/kernel/liveSlots.js
@@ -335,7 +335,7 @@ function build(syscall, _state, makeRoot, forVatID) {
     return pr;
   }
 
-  function deliver(facetid, method, argsbytes, caps, resolverID) {
+  function deliver(facetid, method, argsbytes, caps, { id: resolverID }) {
     lsdebug(
       `ls[${forVatID}].dispatch.deliver ${facetid}.${method} -> ${resolverID}`,
     );

--- a/src/kernel/vatManager.js
+++ b/src/kernel/vatManager.js
@@ -502,7 +502,7 @@ export default function makeVatManager(
           msg.method,
           msg.argsString,
           inputSlots,
-          resolverID,
+          harden({ type: 'resolver', id: resolverID }),
         ],
         `vat[${vatID}][${target.id}].${msg.method} dispatch failed`,
       );

--- a/test/commsSlots/makeCommsSlots/test-deliver.js
+++ b/test/commsSlots/makeCommsSlots/test-deliver.js
@@ -28,7 +28,7 @@ test('makeCommsSlots deliver to commsController (facetid 0)', t => {
     'init',
     '{"args":[{"@qclass":"slot","index":0}]}',
     [vatTP],
-    30,
+    { type: 'resolver', id: 30 },
   );
 
   t.deepEqual(calls[0], [
@@ -81,7 +81,7 @@ test('makeCommsSlots deliver to egress', t => {
     'init',
     '{"args":[{"@qclass":"slot","index":0}]}',
     [vatTP],
-    30,
+    { type: 'resolver', id: 30 },
   );
   t.equal(calls[0][0], 'send');
   calls.shift();
@@ -102,12 +102,13 @@ test('makeCommsSlots deliver to egress', t => {
     'addEgress',
     '{"args":["bot", 70, {"@qclass":"slot","index":0}]}',
     [{ type: 'import', id: 55 }],
-    31,
+    { type: 'resolver', id: 31 },
   );
   t.deepEqual(calls, [['fulfillToData', [31, UNDEFINED, []]]]);
   calls.shift();
 
   const machineArgs = {
+    event: 'send',
     target: { type: 'your-egress', id: 70 },
     methodName: 'bar',
     // args: JSON.stringify([{foo: 1}]),
@@ -164,7 +165,7 @@ test('makeCommsSlots deliver facetid is unexpected', t => {
   const commsSlots = makeCommsSlots(mockSyscall, {}, helpers);
 
   t.throws(() => {
-    commsSlots.deliver(99, 'init', '{"args":["bot","botSigningKey"]}', [], 30);
+    commsSlots.deliver(99, 'init', '{"args":["bot","botSigningKey"]}', [], { type: 'resolver', id: 30 });
   }, "{[Error: unknown facetid] message: 'unknown facetid' }");
   t.equal(calls.length, 0);
   // TODO: init() really ought to notifyReject() upon error, not leave the
@@ -203,7 +204,7 @@ test('makeCommsSlots deliver to ingress', t => {
     'init',
     '{"args":[{"@qclass":"slot","index":0}]}',
     [vatTP],
-    30,
+    { type: 'resolver', id: 30 },
   );
   t.equal(calls[0][0], 'send');
   calls.shift();
@@ -216,12 +217,14 @@ test('makeCommsSlots deliver to ingress', t => {
     'addIngress',
     '{"args":["bot", {"@qclass":"slot","index":0}]}',
     [{ type: 'your-ingress', id: 0 }],
-    31,
+    { type: 'resolver', id: 31 },
   );
   t.deepEqual(calls[0], ['fulfillToPresence', [31, { type: 'export', id: 2 }]]);
   calls.shift();
 
-  commsSlots.deliver(2, 'encourageMe', '{"args":["me"]}', [], 32);
+  commsSlots.deliver(2, 'encourageMe', '{"args":["me"]}', [], {
+    type: 'resolver', id: 32,
+  });
   t.equal(calls[0][0], 'send');
   const args = calls[0][1];
   calls.shift();
@@ -231,7 +234,7 @@ test('makeCommsSlots deliver to ingress', t => {
   t.deepEqual(JSON.parse(args[2]), {
     args: [
       'bot',
-      '{"target":{"type":"your-egress","id":{"@qclass":"slot","index":0}},"methodName":"encourageMe","args":["me"],"slots":[],"resultSlot":{"type":"your-resolver","id":3}}',
+      '{"event":"send","target":{"type":"your-egress","id":{"@qclass":"slot","index":0}},"methodName":"encourageMe","args":["me"],"slots":[],"resultSlot":{"type":"your-resolver","id":3}}',
     ],
   });
   t.deepEqual(args[3], []);

--- a/test/commsSlots/makeCommsSlots/test-deliver.js
+++ b/test/commsSlots/makeCommsSlots/test-deliver.js
@@ -165,7 +165,10 @@ test('makeCommsSlots deliver facetid is unexpected', t => {
   const commsSlots = makeCommsSlots(mockSyscall, {}, helpers);
 
   t.throws(() => {
-    commsSlots.deliver(99, 'init', '{"args":["bot","botSigningKey"]}', [], { type: 'resolver', id: 30 });
+    commsSlots.deliver(99, 'init', '{"args":["bot","botSigningKey"]}', [], {
+      type: 'resolver',
+      id: 30,
+    });
   }, "{[Error: unknown facetid] message: 'unknown facetid' }");
   t.equal(calls.length, 0);
   // TODO: init() really ought to notifyReject() upon error, not leave the
@@ -223,7 +226,8 @@ test('makeCommsSlots deliver to ingress', t => {
   calls.shift();
 
   commsSlots.deliver(2, 'encourageMe', '{"args":["me"]}', [], {
-    type: 'resolver', id: 32,
+    type: 'resolver',
+    id: 32,
   });
   t.equal(calls[0][0], 'send');
   const args = calls[0][1];

--- a/test/commsSlots/makeCommsSlots/test-notifyFulfillToData.js
+++ b/test/commsSlots/makeCommsSlots/test-notifyFulfillToData.js
@@ -6,7 +6,7 @@ const helpers = {
   vatID: 'botcomms',
 };
 
-test('makeCommsSlots notifyFulfillToData', t => {
+test('makeCommsSlots fulfillToData', t => {
   const calls = [];
   const mockSyscall = {
     send(...args) {
@@ -43,7 +43,7 @@ test('makeCommsSlots notifyFulfillToData', t => {
       args: [
         'machine1',
         JSON.stringify({
-          event: 'notifyFulfillToData',
+          event: 'fulfillToData',
           promise: meToYouSlot,
           args: 'hello',
           slots: [],

--- a/test/commsSlots/makeCommsSlots/test-notifyFulfillToPresence.js
+++ b/test/commsSlots/makeCommsSlots/test-notifyFulfillToPresence.js
@@ -5,7 +5,7 @@ const helpers = {
   log: console.log,
 };
 
-test('makeCommsSlots notifyFulfillToPresence', t => {
+test('makeCommsSlots fulfillToPresence', t => {
   const calls = [];
   const mockSyscall = {
     send(...args) {
@@ -48,7 +48,7 @@ test('makeCommsSlots notifyFulfillToPresence', t => {
       args: [
         'abc',
         JSON.stringify({
-          event: 'notifyFulfillToPresence',
+          event: 'fulfillToPresence',
           promise: { type: 'your-ingress', id: 9 },
           target: { type: 'your-egress', id: 3 },
         }),

--- a/test/test-kernel.js
+++ b/test/test-kernel.js
@@ -1102,7 +1102,7 @@ test('transcript', async t => {
       'store',
       'args string',
       [{ id: 1, type: 'export' }, { id: 10, type: 'import' }],
-      null,
+      { id: null, type: 'resolver' },
     ],
     syscalls: [
       {


### PR DESCRIPTION
### Description

This PR removes the incorrect casting (see below for explanation) and cleans up commsSlots. 

What was line [79 of mapOutbound.js]([mapOutbound.js line 79](https://github.com/Agoric/SwingSet/blob/a191a0cb5334dc591b96ead7821ba92200f27ad7/src/kernel/commsSlots/outbound/mapOutbound.js#L79)) has been put in a new function called mapResultSlot which does not do the casting but instead just stores the kernelSlot in the commsSlot cList as type 'resolver'. No matching promise is necessary for this case. 

Clean ups:
1. The `resolverID` that was passed in as the last argument of `deliver` has been changed to a full slot of type 'resolver'. 
2. In messages over the wire, all messages have an event now. Previously, event==='send' was the implicit default and this is now made explicit. 
3. For clarity, `mapInbound` has been split into three functions according to three different scenarios of use: `mapInboundTarget`, `mapInboundSlot`, and `mapInboundResolver`.  `mapInboundTarget` will error if the target isn't found in the clist lookup. `mapInboundResolver` is used only in the case of a message event that involves the resolution of a promise to something, so it always looks for a resolver. (I think mapInboundResolver could be simplified further if liveSlots allowed type:resolver to be passed in. Then, we wouldn't have to hold both a promise and resolver if we create a promise in the commsVat as in mapInbound.js line 43, where we receive an argument slot over the wire with 'your-promise' as the type.) 

### Explanation of [ERTP-30](https://github.com/Agoric/ERTP/issues/30) bug

In dispatch.deliver in both [liveSlots](https://github.com/Agoric/SwingSet/blob/a191a0cb5334dc591b96ead7821ba92200f27ad7/src/kernel/liveSlots.js#L338) and [commsSlots](https://github.com/Agoric/SwingSet/blob/a191a0cb5334dc591b96ead7821ba92200f27ad7/src/kernel/commsSlots/commsSlots.js#L40), we pass in a resolverID that represents the result of that call. 

Lacking the promise part of the result pair, the code in [mapOutbound.js line 79](https://github.com/Agoric/SwingSet/blob/a191a0cb5334dc591b96ead7821ba92200f27ad7/src/kernel/commsSlots/outbound/mapOutbound.js#L79) was creating an object of type promise and id equal to the resolverID. Basically, it was doing an incorrect casting to a promise. But, this collided with another promise id produced later down the line. 

To give an example, a call to tapFaucet had a resolverID of 34. We stored that in our cList representations as resolver:34 and promise:34. Then later, we get an argument slot that is also promise:34. When we look it up in our tables, we find the data that was previously stored, but this is a mistake, because this second promise is unrelated to resolver:34. 
