### PR TITLE
harden E() result promises

### DIFF
--- a/test/basedir-promises-2/bootstrap.js
+++ b/test/basedir-promises-2/bootstrap.js
@@ -1,0 +1,49 @@
+import harden from '@agoric/harden';
+import makePromise from '../../src/kernel/makePromise';
+
+console.log(`loading bootstrap`);
+
+function build(E, log) {
+  return harden({
+    bootstrap(argv, vats) {
+      const mode = argv[0];
+      if (mode === 'harden-promise-1') {
+        const { p: p1 } = makePromise();
+        harden(p1);
+        const allP = [];
+        // in bug #95, this first call returns a (correctly) frozen Promise,
+        // but for the wrong reasons
+        const p2 = E(vats.left).checkHarden(p1);
+        log(`p2 frozen ${Object.isFrozen(p2)}`);
+        allP.push(p2);
+        // but this one does not:
+        const p3 = E(p2).checkHarden(p1);
+        log(`p3 frozen ${Object.isFrozen(p3)}`);
+        allP.push(p3);
+        // TODO: this one doesn't get frozen, but we wish it did
+        // const p4 = vats.left!checkHarden(p1);
+        // log(`p4 frozen ${Object.isFrozen(p4)}`);
+        // allP.push(p4);
+        Promise.all(allP).then(_ => {
+          log(`b.harden-promise-1.finish`);
+        });
+      } else {
+        throw Error(`unknown mode ${mode}`);
+      }
+    },
+  });
+}
+
+export default function setup(syscall, state, helpers) {
+  function log(what) {
+    helpers.log(what);
+    console.log(what);
+  }
+  log(`bootstrap called`);
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, log),
+    helpers.vatID,
+  );
+}

--- a/test/basedir-promises-2/vat-left.js
+++ b/test/basedir-promises-2/vat-left.js
@@ -1,0 +1,20 @@
+import harden from '@agoric/harden';
+
+function build(E, log) {
+  const obj0 = {
+    checkHarden(o1) {
+      log(`o1 frozen ${Object.isFrozen(o1)}`);
+      return harden(obj0);
+    },
+  };
+  return harden(obj0);
+}
+
+export default function setup(syscall, state, helpers) {
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, helpers.log),
+    helpers.vatID,
+  );
+}

--- a/test/test-promises.js
+++ b/test/test-promises.js
@@ -165,3 +165,36 @@ test('send-promise-resolve-to-local with SES', async t => {
 test('send-promise-resolve-to-local without SES', async t => {
   await testSendPromise1(t, false);
 });
+
+async function testHardenPromise1(t, withSES) {
+  const config = await loadBasedir(
+    path.resolve(__dirname, 'basedir-promises-2'),
+  );
+  const c = await buildVatController(config, withSES, ['harden-promise-1']);
+
+  await c.run();
+  t.deepEqual(c.dump().log, [
+    'bootstrap called',
+    'p2 frozen true',
+    'p3 frozen true',
+    // TODO: p4 = x!foo(), and we'd like it to be frozen, but the Handled
+    // Promise API does not currently provide a place for us to freeze it.
+    // See #95 for details.
+    // 'p4 frozen true',
+    // 'o1 frozen true',
+    'o1 frozen true',
+    'o1 frozen true',
+    'b.harden-promise-1.finish',
+  ]);
+  t.end();
+}
+
+test('send-harden-promise-1 with SES', async t => {
+  await testHardenPromise1(t, true);
+});
+
+// TODO: if/when we re-enable the infix-bang x!foo(), this test will only run
+// under SES, so disable the non-SES version
+test('send-harden-promise-1 without SES', async t => {
+  await testHardenPromise1(t, false);
+});


### PR DESCRIPTION
refs #95

I think this one will fix everything that can be fixed. `x!foo()` returns unfrozen Promises, because we have no place to freeze them, but `E(x).foo()` and `E(E(x).foo()).bar()` are both frozen.

I upgraded SwingSet trunk to eventual-send-0.2.0, so we should no longer be sometimes getting frozen promises from Promise `.post()` methods.
