### PR TITLE
@agoric/default-evaluate-options: use it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,25 @@
       "resolved": "https://registry.npmjs.org/@agoric/babel-parser/-/babel-parser-7.5.0.tgz",
       "integrity": "sha512-lWAVssRdJBK1Rr7lndOdJ24qaG/r8dIY43oUFumQr0FW9f4oID2WZoBlX7pDBdwZXHIHIvYa+p09q5obYBoROw=="
     },
+    "@agoric/default-evaluate-options": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.1.0.tgz",
+      "integrity": "sha512-9yloipU26stjHC5fKTDIe3JUb7jHPNg0bfSxHye27rMIZgl+KcrDzjs5bdhrXIYZwYzert6RcCfQzkJMAWDtDA==",
+      "requires": {
+        "@agoric/babel-parser": "^7.5.0",
+        "@agoric/eventual-send": "^0.1.11",
+        "@agoric/transform-bang": "^0.3.1",
+        "@babel/generator": "^7.5.5",
+        "esm": "^3.2.5"
+      },
+      "dependencies": {
+        "@agoric/eventual-send": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.1.11.tgz",
+          "integrity": "sha512-iQ8Ley6LBErUIYH5ZetU3IeyzwrXsoru5LLvAY0vc2pVlIMUZ0wRGzaWIEcVWSRKUDh5/n1LJXz/bVJ7d1MHZg=="
+        }
+      }
+    },
     "@agoric/evaluate": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@agoric/evaluate/-/evaluate-1.1.0.tgz",
@@ -31,11 +50,6 @@
       "requires": {
         "esm": "^3.2.5"
       }
-    },
-    "@agoric/eventual-send": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.2.0.tgz",
-      "integrity": "sha512-r4nT3mk0zj5iXebI819XHO1pj5HNGwTHLqnQLarXXdOXym4keUqf07pmZ2L/8joniR0rjC5GlvHuc7o551EWUA=="
     },
     "@agoric/harden": {
       "version": "0.0.4",
@@ -66,9 +80,9 @@
       "integrity": "sha512-puvWkoaJovQib/YaSRSGJ8Kn9rogi/yyaVa3d5znSZb5WiYfUiEKW35BfexHhAdi0VfPz2anFHoRBoBSUIijNA=="
     },
     "@agoric/transform-bang": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@agoric/transform-bang/-/transform-bang-0.3.1.tgz",
-      "integrity": "sha512-Qhbf71pM3n/o/VSmsL38n9Yk8P0BTi+/UuXbySo9hmzWTLofHeUU1luI/CrRUtz6z6Fqt5JvAhiMIxcJdAthsg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@agoric/transform-bang/-/transform-bang-0.3.3.tgz",
+      "integrity": "sha512-3UkAooZ/Y4tqgvWNyW5mT1lnFmXklyb4wirB7rCtkp60WQtinfsevl6uLtYI2Q8cxgdbSwLr11v/HfuPNdWNBA==",
       "requires": {
         "@agoric/harden": "0.0.4",
         "esm": "^3.2.5"
@@ -83,97 +97,16 @@
         "@babel/highlight": "^7.0.0"
       }
     },
-    "@babel/core": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
-      "integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.5.0",
-        "@babel/helpers": "^7.5.4",
-        "@babel/parser": "^7.5.0",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.0",
-        "@babel/types": "^7.5.0",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.11",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
-          "integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        }
-      }
-    },
     "@babel/generator": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
-      "integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
       "requires": {
-        "@babel/types": "^7.5.0",
+        "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/helper-plugin-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.4.4"
-      }
-    },
-    "@babel/helpers": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
-      "integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.0",
-        "@babel/types": "^7.5.0"
       }
     },
     "@babel/highlight": {
@@ -187,57 +120,13 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
-          "integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.0.tgz",
-      "integrity": "sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.5.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.5.0",
-        "@babel/types": "^7.5.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
-          "integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
-          "dev": true
-        }
-      }
-    },
     "@babel/types": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
-      "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -351,14 +240,6 @@
         "ast-types-flow": "0.0.7"
       }
     },
-    "babel-plugin-syntax-infix-bang": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-infix-bang/-/babel-plugin-syntax-infix-bang-7.4.5.tgz",
-      "integrity": "sha512-t/cbQglQKM9tF+RQ8OQQI4dG3YUSVpVDRCpeaNGMzj9o44Dx6m/gx6350PDpNCRN57ZLDbG7oZl6QErtAIVopQ==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -469,15 +350,6 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
-    },
-    "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1371,23 +1243,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json5": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
     },
     "jsx-ast-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/main.js",
   "module": "src/index.js",
   "engines": {
-    "node": ">=12.0"
+    "node": ">=11.0"
   },
   "bin": {
     "vat": "bin/vat"
@@ -23,7 +23,6 @@
     "lint-check": "eslint '**/*.{js,jsx}'"
   },
   "devDependencies": {
-    "@babel/core": "^7.5.4",
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.0.0",
@@ -39,15 +38,11 @@
   },
   "dependencies": {
     "@agoric/acorn-infix-bang": "0.0.4",
-    "@agoric/babel-parser": "^7.5.0",
+    "@agoric/default-evaluate-options": "^0.1.0",
     "@agoric/evaluate": "^1.1.0",
-    "@agoric/eventual-send": "^0.2.0",
     "@agoric/harden": "^0.0.4",
     "@agoric/marshal": "0.0.1",
     "@agoric/nat": "^2.0.0",
-    "@agoric/transform-bang": "^0.3.1",
-    "@babel/generator": "^7.5.0",
-    "babel-plugin-syntax-infix-bang": "^7.4.5",
     "rollup": "^1.16.7",
     "rollup-plugin-node-resolve": "^5.0.1",
     "semver": "^6.1.0",


### PR DESCRIPTION
This new module encapsulates all the options we want to pass down to realms-shim or @agoric/evaluate.

Notably, it also backs out @agoric/eventual-send@0.2.0 that broke ERTP in favour of 0.1.11 which only introduces proper asynchronous defences.

We really should release SwingSet 0.0.18 right away, as 0.0.17 was quite broken (out of memory errors).  We'll work on eventual-send@0.2.1, but more gradually to find and fix what was causing the breakage.
