### PR TITLE
test/test-node-version.js: only require Node 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
 
   # Lint and Test
 
-  lint_and_test_node_12: &lint_and_test
+  lint_and_test_node_11: &lint_and_test
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:11
     steps: 
       - checkout
       - *install_npm
@@ -45,7 +45,7 @@ jobs:
 
   # Automated Npm Audit Fix PR
 
-  npm_audit_node_12: &npm_audit
+  npm_audit_node_11: &npm_audit
     docker:
       - image: circleci/golang:1.12.0-node
     steps: 
@@ -69,7 +69,7 @@ workflows:
   version: 2
   test_all:
     jobs:
-      - lint_and_test_node_12
+      - lint_and_test_node_11
   nightly:
      triggers:
        - schedule:
@@ -79,4 +79,4 @@ workflows:
                only:
                  - master
      jobs:
-        - npm_audit_node_12
+        - npm_audit_node_11

--- a/test/test-node-version.js
+++ b/test/test-node-version.js
@@ -5,8 +5,8 @@ import { test } from 'tape-promise/tape';
 
 test('Node version', t => {
   t.true(
-    semver.satisfies(process.version, '>=12.0'),
-    'we need Node 11 where the IO queue is higher priority than the Promise queue, and Node 12 for a different ordering issue (see #99 for details)',
+    semver.satisfies(process.version, '>=11.0'),
+    'we need Node 11 where the IO queue is higher priority than the Promise queue',
   );
   t.end();
 });


### PR DESCRIPTION
The Node 12 ordering differences were only tickled by a bug in
@agoric/eventual-send v0.2.x.  The new version installed in the
SwingSet dependencies does not have this problem.

fixes #99