### PR TITLE
have vats allocate promiseIDs themselves, remove syscall.createPromise()

### DIFF
--- a/src/kernel/deviceManager.js
+++ b/src/kernel/deviceManager.js
@@ -42,7 +42,7 @@ export default function makeDeviceManager(
       method,
       argsString,
       slots,
-      kernelResolverID: undefined,
+      result: null,
     };
     send(target, msg);
   }

--- a/src/kernel/kernel.js
+++ b/src/kernel/kernel.js
@@ -8,7 +8,7 @@ import makeVatManager from './vatManager';
 import makeDeviceManager from './deviceManager';
 import makeKernelKeeper from './state/kernelKeeper';
 import { insistKernelType, parseKernelSlot } from './parseKernelSlots';
-import { insistVatType, makeVatSlot } from '../vats/parseVatSlots';
+import { makeVatSlot } from '../vats/parseVatSlots';
 import { insist } from './insist';
 
 function abbreviateReviver(_, arg) {
@@ -236,7 +236,6 @@ export default function buildKernel(kernelEndowments, initialState = '{}') {
 
   function addImport(forVatID, what) {
     const kernelSlot = `${what}`;
-    insistKernelType('object', kernelSlot);
     if (!started) {
       throw new Error('must do kernel.start() before addImport()');
       // because otherwise we can't get the vatManager
@@ -247,7 +246,6 @@ export default function buildKernel(kernelEndowments, initialState = '{}') {
 
   function addExport(fromVatID, what) {
     const vatSlot = `${what}`;
-    insistVatType('object', vatSlot);
     if (!started) {
       throw new Error('must do kernel.start() before addExport()');
       // because otherwise we can't get the vatManager

--- a/src/kernel/kernel.js
+++ b/src/kernel/kernel.js
@@ -277,7 +277,7 @@ export default function buildKernel(kernelEndowments, initialState = '{}') {
           // queue() is exposed to the controller's realm, so we must translate
           // each slot into a kernel-realm object/array
           slots: Array.from(slots.map(s => `${s}`)),
-          kernelResolverID: null, // this will be json stringified
+          result: null, // this will be json stringified
         },
       }),
     );

--- a/src/kernel/kernel.js
+++ b/src/kernel/kernel.js
@@ -69,15 +69,6 @@ export default function buildKernel(kernelEndowments, initialState = '{}') {
   }
   */
 
-  function createPromiseWithDecider(deciderVatID) {
-    // deciderVatID can be undefined if the promise is "owned" by the kernel
-    // (pipelining)
-
-    // TODO: not true (but we should make it true): kernel promise is
-    // replaced if altered, so we can safely harden
-    return kernelKeeper.addKernelPromise(deciderVatID);
-  }
-
   function makeError(s) {
     // TODO: create a @qclass=error, once we define those
     // or maybe replicate whatever happens with {}.foo()
@@ -224,7 +215,6 @@ export default function buildKernel(kernelEndowments, initialState = '{}') {
 
   const syscallManager = {
     kdebug,
-    createPromiseWithDecider,
     send,
     fulfillToData,
     fulfillToPresence,

--- a/src/kernel/liveSlots.js
+++ b/src/kernel/liveSlots.js
@@ -75,13 +75,13 @@ function build(syscall, _state, makeRoot, forVatID) {
   }
 
   function exportPromise(p) {
-    const pr = syscall.createPromise();
+    const pid = syscall.createPromise();
     // we ignore the kernel promise, but we use the resolver to notify the
     // kernel when our local promise changes state
-    lsdebug(`ls exporting promise ${pr.resolverID}`);
+    lsdebug(`ls exporting promise ${pid}`);
     // eslint-disable-next-line no-use-before-define
-    p.then(thenResolve(pr.resolverID), thenReject(pr.resolverID));
-    return pr.promiseID;
+    p.then(thenResolve(pid), thenReject(pid));
+    return pid;
   }
 
   function exportPassByPresence() {
@@ -188,7 +188,8 @@ function build(syscall, _state, makeRoot, forVatID) {
     const done = makePromise();
     const ser = m.serialize(harden({ args }));
     lsdebug(`ls.qm send(${JSON.stringify(targetSlot)}, ${prop}`);
-    const promiseID = syscall.send(targetSlot, prop, ser.argsString, ser.slots);
+    const promiseID = syscall.createPromise(); // temporary
+    syscall.send(targetSlot, prop, ser.argsString, ser.slots, promiseID);
     insistVatType('promise', promiseID);
     lsdebug(` ls.qm got promiseID ${promiseID}`);
 
@@ -315,9 +316,9 @@ function build(syscall, _state, makeRoot, forVatID) {
     return pr;
   }
 
-  function deliver(target, method, argsbytes, caps, resolverID) {
+  function deliver(target, method, argsbytes, caps, result) {
     lsdebug(
-      `ls[${forVatID}].dispatch.deliver ${target}.${method} -> ${resolverID}`,
+      `ls[${forVatID}].dispatch.deliver ${target}.${method} -> ${result}`,
     );
     const t = slotToVal.get(target);
     if (!t) {
@@ -341,17 +342,17 @@ function build(syscall, _state, makeRoot, forVatID) {
       }
       return t[method](...args.args);
     });
-    if (resolverID !== undefined && resolverID !== null) {
-      lsdebug(` ls.deliver attaching then ->${resolverID}`);
-      insistVatType('resolver', resolverID); // temporary
+    if (result) {
+      lsdebug(` ls.deliver attaching then ->${result}`);
+      insistVatType('promise', result);
       // eslint-disable-next-line no-use-before-define
-      p.then(thenResolve(resolverID), thenReject(resolverID));
+      p.then(thenResolve(result), thenReject(result));
     }
     return p;
   }
 
-  function thenResolve(resolverID) {
-    insistVatType('resolver', resolverID); // temporary
+  function thenResolve(promiseID) {
+    insistVatType('promise', promiseID);
     return res => {
       harden(res);
       lsdebug(`ls.thenResolve fired`, res);
@@ -370,36 +371,26 @@ function build(syscall, _state, makeRoot, forVatID) {
         const slot = ser.slots[unser.index];
         const { type } = parseVatSlot(slot);
         if (type === 'object') {
-          syscall.fulfillToPresence(resolverID, slot);
+          syscall.fulfillToPresence(promiseID, slot);
         } else {
           throw new Error(`thenResolve to non-object slot ${slot}`);
         }
       } else {
         // if it resolves to data, .thens fire but kernel-queued messages are
         // rejected, because you can't send messages to data
-        syscall.fulfillToData(resolverID, ser.argsString, ser.slots);
+        syscall.fulfillToData(promiseID, ser.argsString, ser.slots);
       }
     };
   }
 
-  function thenReject(resolverID) {
+  function thenReject(promiseID) {
     return rej => {
       harden(rej);
       lsdebug(`ls thenReject fired`, rej);
       const ser = m.serialize(rej);
-      syscall.reject(resolverID, ser.argsString, ser.slots);
+      syscall.reject(promiseID, ser.argsString, ser.slots);
     };
   }
-
-  /*
-  function subscribe(resolverID) {
-    lsdebug(`ls.dispatch.subscribe(${resolverID})`);
-    if (!exportedPromisesByResolverID.has(resolverID)) {
-      throw new Error(`unknown resolverID '${resolverID}'`);
-    }
-    const p = exportedPromisesByResolverID.get(resolverID);
-    p.then(thenResolve(resolverID), thenReject(resolverID));
-  } */
 
   function notifyFulfillToData(promiseID, data, slots) {
     lsdebug(`ls.dispatch.notifyFulfillToData(${promiseID}, ${data}, ${slots})`);

--- a/src/kernel/liveSlots.js
+++ b/src/kernel/liveSlots.js
@@ -67,6 +67,7 @@ function build(syscall, _state, makeRoot, forVatID) {
   const slotToVal = new Map();
   const importedPromisesByPromiseID = new Map();
   let nextExportID = 1;
+  let nextPromiseID = 5;
 
   function allocateExportID() {
     const exportID = nextExportID;
@@ -74,10 +75,14 @@ function build(syscall, _state, makeRoot, forVatID) {
     return exportID;
   }
 
+  function allocatePromiseID() {
+    const promiseID = nextPromiseID;
+    nextPromiseID += 1;
+    return makeVatSlot('promise', true, promiseID);
+  }
+
   function exportPromise(p) {
-    const pid = syscall.createPromise();
-    // we ignore the kernel promise, but we use the resolver to notify the
-    // kernel when our local promise changes state
+    const pid = allocatePromiseID();
     lsdebug(`ls exporting promise ${pid}`);
     // eslint-disable-next-line no-use-before-define
     p.then(thenResolve(pid), thenReject(pid));
@@ -187,24 +192,22 @@ function build(syscall, _state, makeRoot, forVatID) {
   function queueMessage(targetSlot, prop, args) {
     const done = makePromise();
     const ser = m.serialize(harden({ args }));
-    lsdebug(`ls.qm send(${JSON.stringify(targetSlot)}, ${prop}`);
-    const promiseID = syscall.createPromise(); // temporary
-    syscall.send(targetSlot, prop, ser.argsString, ser.slots, promiseID);
-    insistVatType('promise', promiseID);
-    lsdebug(` ls.qm got promiseID ${promiseID}`);
+    const pid = allocatePromiseID();
+    lsdebug(`ls.qm send(${JSON.stringify(targetSlot)}, ${prop}) -> ${pid}`);
+    syscall.send(targetSlot, prop, ser.argsString, ser.slots, pid);
 
     // prepare for notifyFulfillToData/etc
-    importedPromisesByPromiseID.set(promiseID, done);
+    importedPromisesByPromiseID.set(pid, done);
 
     // ideally we'd wait until someone .thens done.p, but with native
     // Promises we have no way of spotting that, so subscribe immediately
-    lsdebug(`ls[${forVatID}].queueMessage.importedPromiseThen ${promiseID}`);
-    importedPromiseThen(promiseID);
+    lsdebug(`ls[${forVatID}].queueMessage.importedPromiseThen ${pid}`);
+    importedPromiseThen(pid);
 
     // prepare the serializer to recognize it, if it's used as an argument or
     // return value
-    valToSlot.set(done.p, promiseID);
-    slotToVal.set(promiseID, done.p);
+    valToSlot.set(done.p, pid);
+    slotToVal.set(pid, done.p);
 
     return done.p;
   }

--- a/src/kernel/state/vatKeeper.js
+++ b/src/kernel/state/vatKeeper.js
@@ -1,6 +1,6 @@
 import harden from '@agoric/harden';
 import { insist } from '../insist';
-import { insistKernelType, parseKernelSlot } from '../parseKernelSlots';
+import { parseKernelSlot } from '../parseKernelSlots';
 import { makeVatSlot, parseVatSlot } from '../../vats/parseVatSlots';
 
 // makeVatKeeper is a pure function: all state is kept in the argument object
@@ -12,11 +12,6 @@ export default function makeVatKeeper(
   addKernelPromise,
 ) {
   function createStartingVatState() {
-    // kernelSlotToVatSlot is an object with four properties:
-    //    exports, devices, promises, resolvers.
-    // vatSlotToKernelSlot has imports, deviceImports, promises,
-    //    resolvers
-
     state.kernelSlotToVatSlot = {}; // kpNN -> p+NN, etc
     state.vatSlotToKernelSlot = {}; // p+NN -> kpNN, etc
 
@@ -93,20 +88,6 @@ export default function makeVatKeeper(
     return state.kernelSlotToVatSlot[kernelSlot];
   }
 
-  // temporary
-  function mapKernelPromiseToVatResolver(kernelSlot) {
-    insistKernelType('promise', kernelSlot);
-    const vp = mapKernelSlotToVatSlot(kernelSlot);
-    const parsed = parseVatSlot(vp);
-    const vr = makeVatSlot('resolver', parsed.allocatedByVat, parsed.id);
-    const existing = state.vatSlotToKernelSlot[vr];
-    if (existing === undefined) {
-      // the vat resolver and the vat promise both map to the kernel promise
-      state.vatSlotToKernelSlot[vr] = kernelSlot;
-    }
-    return vr;
-  }
-
   function getTranscript() {
     return Array.from(state.transcript);
   }
@@ -129,7 +110,6 @@ export default function makeVatKeeper(
     createStartingVatState,
     mapVatSlotToKernelSlot,
     mapKernelSlotToVatSlot,
-    mapKernelPromiseToVatResolver,
     getTranscript,
     dumpState,
     addToTranscript,

--- a/src/kernel/vatManager.js
+++ b/src/kernel/vatManager.js
@@ -13,7 +13,6 @@ export default function makeVatManager(
 ) {
   const {
     kdebug,
-    createPromiseWithDecider,
     send,
     fulfillToData,
     fulfillToPresence,
@@ -148,15 +147,6 @@ export default function makeVatManager(
       result,
     };
     send(target, msg);
-  }
-
-  function doCreatePromise() {
-    const kernelPromiseID = createPromiseWithDecider(vatID);
-    const p = mapKernelSlotToVatSlot(kernelPromiseID);
-    kdebug(
-      `syscall[${vatID}].createPromise -> (vat:${p}=ker:${kernelPromiseID})`,
-    );
-    return p;
   }
 
   function doSubscribe(promiseID) {
@@ -299,13 +289,6 @@ export default function makeVatManager(
       // todo: remove return value
       transcriptAddSyscall(['send', ...args], promiseID);
       return promiseID;
-    },
-    createPromise(...args) {
-      const pr = inReplay
-        ? replay('createPromise', ...args)
-        : doCreatePromise(...args);
-      transcriptAddSyscall(['createPromise', ...args], pr);
-      return pr;
     },
     subscribe(...args) {
       transcriptAddSyscall(['subscribe', ...args]);

--- a/src/vats/comms/controller.js
+++ b/src/vats/comms/controller.js
@@ -19,7 +19,7 @@ export function deliverToController(
   method,
   data,
   slots,
-  resolverID,
+  result,
   syscall,
 ) {
   function doAddRemote(args) {
@@ -30,7 +30,7 @@ export function deliverToController(
     }
     const transmitterID = slots[args[1].index];
     const { receiverID } = addRemote(state, name, transmitterID);
-    syscall.fulfillToPresence(resolverID, receiverID);
+    syscall.fulfillToPresence(result, receiverID);
   }
 
   function doAddEgress(args) {
@@ -43,7 +43,7 @@ export function deliverToController(
     }
     const localRef = slots[args[2].index];
     addEgress(state, remoteID, remoteRefID, localRef);
-    syscall.fulfillToData(resolverID, UNDEFINED, []);
+    syscall.fulfillToData(result, UNDEFINED, []);
   }
 
   function doAddIngress(args) {
@@ -52,7 +52,7 @@ export function deliverToController(
     const remoteID = state.names.get(remoteName);
     const remoteRefID = Nat(args[1]);
     const localRef = addIngress(state, remoteID, remoteRefID);
-    syscall.fulfillToPresence(resolverID, localRef);
+    syscall.fulfillToPresence(result, localRef);
   }
 
   // This is a degenerate form of deserialization, just enough to handle the

--- a/src/vats/comms/inbound.js
+++ b/src/vats/comms/inbound.js
@@ -5,6 +5,7 @@ import {
   parseRemoteSlot,
 } from './parseRemoteSlot';
 import { mapInbound, getInbound } from './clist';
+import { allocatePromise } from './state';
 import { insist } from '../../kernel/insist';
 
 export function deliverFromRemote(syscall, state, remoteID, message) {
@@ -28,11 +29,11 @@ export function deliverFromRemote(syscall, state, remoteID, message) {
     const body = message.slice(sci + 1);
     let r;
     if (result.length) {
-      // todo: replace with mapInboundResult
+      // todo: replace with mapInboundResult, allow pre-existing promises if
+      // the decider is right
       insistRemoteType('promise', result);
       insist(!parseRemoteSlot(result).allocatedByRecipient, result); // temp?
-      // for now p is p-NN, later we will allocate+provide p+NN instead
-      r = syscall.createPromise(); // temporary
+      r = allocatePromise(state);
       state.promiseTable.set(r, {
         owner: remoteID,
         resolved: false,

--- a/src/vats/comms/state.js
+++ b/src/vats/comms/state.js
@@ -1,3 +1,5 @@
+import { makeVatSlot } from '../parseVatSlots';
+
 export function makeState() {
   const state = {
     nextRemoteIndex: 1,
@@ -44,8 +46,8 @@ export function dumpState(state) {
   }
 }
 
-export function allocatePromiseIndex(state) {
+export function allocatePromise(state) {
   const index = state.nextPromiseIndex;
   state.nextPromiseIndex += 1;
-  return index;
+  return makeVatSlot('promise', true, index);
 }

--- a/test/basedir-commsvat/vat-left.js
+++ b/test/basedir-commsvat/vat-left.js
@@ -47,8 +47,7 @@ export default function setup(syscall, state, helpers) {
 
           case 'left does: E(right.0).method(left.1) => returnData': {
             const rightRootPresence = args[0];
-            const leftRootPresence = args[1];
-            const leftNewObjPresence = await E(leftRootPresence).createNewObj();
+            const leftNewObjPresence = createNewObj();
             E(rightRootPresence)
               .methodWithPresence(leftNewObjPresence)
               .then(r => log(`=> left vat receives the returnedData: ${r}`));
@@ -57,8 +56,7 @@ export default function setup(syscall, state, helpers) {
 
           case 'left does: E(right.0).method(left.1) => returnData twice': {
             const rightRootPresence = args[0];
-            const leftRootPresence = args[1];
-            const leftNewObjPresence = await E(leftRootPresence).createNewObj();
+            const leftNewObjPresence = createNewObj();
 
             // first time
             E(rightRootPresence)
@@ -225,7 +223,6 @@ export default function setup(syscall, state, helpers) {
 
       return harden({
         startTest,
-        createNewObj,
       });
     },
     helpers.vatID,

--- a/test/files-devices/bootstrap-0.js
+++ b/test/files-devices/bootstrap-0.js
@@ -3,7 +3,7 @@ const harden = require('@agoric/harden');
 export default function setup(syscall, state, helpers, _devices) {
   const { log } = helpers;
   const dispatch = harden({
-    deliver(facetid, method, argsbytes, caps, _resolverID) {
+    deliver(facetid, method, argsbytes, caps, _result) {
       log(argsbytes);
       log(JSON.stringify(caps));
     },

--- a/test/files-devices/bootstrap-1.js
+++ b/test/files-devices/bootstrap-1.js
@@ -4,7 +4,7 @@ export default function setup(syscall, state, helpers, _devices) {
   const { log } = helpers;
   let deviceRef;
   const dispatch = harden({
-    deliver(facetid, method, argsbytes, caps, _resolverID) {
+    deliver(facetid, method, argsbytes, caps, _result) {
       if (method === 'bootstrap') {
         const { args } = JSON.parse(argsbytes);
         const deviceIndex = args[2].d1.index;

--- a/test/test-comms-integration.js
+++ b/test/test-comms-integration.js
@@ -21,6 +21,13 @@ export function runTest(testType, withSES, testStr, expectedLogs) {
   const expected = setupLogs.concat(expectedLogs);
   testType(testStr, async t => {
     const c = await runVats(t, withSES, [testStr]);
+    /*
+    while (c.dump().runQueue.length) {
+      console.log('-');
+      console.log(`--- turn starts`);
+      await c.step();
+      //console.log(c.dump().kernelTable);
+    } */
     await c.run();
     const { log } = c.dump();
     t.deepEqual(log, expected);

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -146,7 +146,7 @@ async function bootstrapExport(t, withSES) {
   ]);
   kt.push([left0, '_bootstrap', 'o-50']);
   kt.push([right0, '_bootstrap', 'o-51']);
-  kt.push([fooP, '_bootstrap', 'p-60']);
+  kt.push([fooP, '_bootstrap', 'p+5']);
   checkKT(t, c, kt);
   t.deepEqual(c.dump().runQueue, [
     {
@@ -173,7 +173,7 @@ async function bootstrapExport(t, withSES) {
   ]);
   kt.push([right0, 'left', 'o-50']);
   kt.push([fooP, 'left', 'p-60']);
-  kt.push([barP, 'left', 'p-61']);
+  kt.push([barP, 'left', 'p+5']);
   checkKT(t, c, kt);
 
   t.deepEqual(c.dump().runQueue, [

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -28,7 +28,7 @@ async function simpleCall(t, withSES) {
     {
       msg: {
         argsString: 'args',
-        kernelResolverID: null,
+        result: null,
         method: 'foo',
         slots: [],
       },
@@ -119,7 +119,7 @@ async function bootstrapExport(t, withSES) {
       msg: {
         argsString:
           '{"args":[[],{"_bootstrap":{"@qclass":"slot","index":0},"left":{"@qclass":"slot","index":1},"right":{"@qclass":"slot","index":2}},{"_dummy":"dummy"}]}',
-        kernelResolverID: null,
+        result: null,
         method: 'bootstrap',
         slots: [boot0, left0, right0],
       },
@@ -157,7 +157,7 @@ async function bootstrapExport(t, withSES) {
         method: 'foo',
         argsString: '{"args":[1,{"@qclass":"slot","index":0}]}',
         slots: [right0],
-        kernelResolverID: fooP,
+        result: fooP,
       },
     },
   ]);
@@ -185,7 +185,7 @@ async function bootstrapExport(t, withSES) {
         method: 'bar',
         argsString: '{"args":[2,{"@qclass":"slot","index":0}]}',
         slots: [right0],
-        kernelResolverID: barP,
+        result: barP,
       },
     },
     { type: 'notifyFulfillToData', vatID: '_bootstrap', kernelPromiseID: fooP },

--- a/test/test-liveslots.js
+++ b/test/test-liveslots.js
@@ -1,0 +1,94 @@
+// eslint-disable-next-line no-redeclare
+/* global setImmediate */
+import { test } from 'tape-promise/tape';
+import harden from '@agoric/harden';
+// eslint-disable-next-line no-unused-vars
+import evaluateExpr from '@agoric/evaluate'; // to get Promise.makeHandled
+import buildKernel from '../src/kernel/index';
+import { makeLiveSlots } from '../src/kernel/liveSlots';
+
+test('calls', async t => {
+  const kernel = buildKernel({ setImmediate });
+  const log = [];
+  let syscall;
+
+  function setupBootstrap(syscallBootstrap, _state, _helpers) {
+    syscall = syscallBootstrap;
+    function deliver(facetID, method, argsString, slots, result) {
+      log.push(['deliver', facetID, method, argsString, slots, result]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('bootstrap', setupBootstrap);
+
+  function setup(syscallVat, state, helpers) {
+    function build(_E, _D) {
+      return harden({
+        one() {
+          log.push('one');
+        },
+        two(p) {
+          log.push(`two ${Promise.resolve(p) === p}`);
+          p.then(res => log.push(['res', res]), rej => log.push(['rej', rej]));
+        },
+      });
+    }
+    return makeLiveSlots(syscallVat, state, build, helpers.vatID);
+  }
+  kernel.addGenesisVat('vat', setup);
+
+  await kernel.start('bootstrap', `[]`);
+  // cycle past the bootstrap() call
+  await kernel.step();
+  log.shift();
+  t.deepEqual(kernel.dump().runQueue, []);
+
+  const root = kernel.addImport('bootstrap', kernel.addExport('vat', 'o+0'));
+
+  // root!one() // sendOnly
+  syscall.send(root, 'one', JSON.stringify({ args: [] }), [], undefined);
+
+  await kernel.step();
+  t.deepEqual(log.shift(), 'one');
+  t.deepEqual(kernel.dump().runQueue, []);
+  // console.log(kernel.dump().runQueue);
+
+  // pr = makePromise()
+  // root!two(pr.promise)
+  // pr.resolve('result')
+  syscall.send(
+    root,
+    'two',
+    JSON.stringify({ args: [{ '@qclass': 'slot', index: 0 }] }),
+    ['p+1'],
+    undefined,
+  );
+  await kernel.step();
+  t.deepEqual(log.shift(), 'two true');
+
+  syscall.fulfillToData('p+1', JSON.stringify('result'), []);
+  await kernel.step();
+  t.deepEqual(log.shift(), ['res', 'result']);
+
+  // pr = makePromise()
+  // root!two(pr.promise)
+  // pr.reject('rejection')
+
+  syscall.send(
+    root,
+    'two',
+    JSON.stringify({ args: [{ '@qclass': 'slot', index: 0 }] }),
+    ['p+2'],
+    undefined,
+  );
+  await kernel.step();
+  t.deepEqual(log.shift(), 'two true');
+
+  syscall.reject('p+2', JSON.stringify('rejection'), []);
+  await kernel.step();
+  t.deepEqual(log.shift(), ['rej', 'rejection']);
+
+  // TODO: more calls, more slot types
+
+  t.end();
+});

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -250,16 +250,16 @@ test('serialize promise', async t => {
   const { p, res } = makePromise();
   t.deepEqual(m.serialize(p), {
     argsString: '{"@qclass":"slot","index":0}',
-    slots: ['p-1'],
+    slots: ['p+5'],
   });
   // serializer should remember the promise
   t.deepEqual(m.serialize(harden(['other stuff', p])), {
     argsString: '["other stuff",{"@qclass":"slot","index":0}]',
-    slots: ['p-1'],
+    slots: ['p+5'],
   });
 
   // inbound should recognize it and return the promise
-  t.deepEqual(m.unserialize('{"@qclass":"slot","index":0}', ['p-1']), p);
+  t.deepEqual(m.unserialize('{"@qclass":"slot","index":0}', ['p+5']), p);
 
   res(5);
   t.deepEqual(log, []);
@@ -267,7 +267,7 @@ test('serialize promise', async t => {
   const { p: pauseP, res: pauseRes } = makePromise();
   setImmediate(() => pauseRes());
   await pauseP;
-  t.deepEqual(log, [{ result: 'p-1', data: '5', slots: [] }]);
+  t.deepEqual(log, [{ result: 'p+5', data: '5', slots: [] }]);
 
   t.end();
 });

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -239,13 +239,10 @@ test('serialize promise', async t => {
   const log = [];
   const syscall = {
     createPromise() {
-      return {
-        promiseID: 'p-1',
-        resolverID: 'r-1',
-      };
+      return 'p-1';
     },
-    fulfillToData(resolverID, data, slots) {
-      log.push({ resolverID, data, slots });
+    fulfillToData(result, data, slots) {
+      log.push({ result, data, slots });
     },
   };
 
@@ -270,7 +267,7 @@ test('serialize promise', async t => {
   const { p: pauseP, res: pauseRes } = makePromise();
   setImmediate(() => pauseRes());
   await pauseP;
-  t.deepEqual(log, [{ resolverID: 'r-1', data: '5', slots: [] }]);
+  t.deepEqual(log, [{ result: 'p-1', data: '5', slots: [] }]);
 
   t.end();
 });

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -238,9 +238,6 @@ test('serialize imports', async t => {
 test('serialize promise', async t => {
   const log = [];
   const syscall = {
-    createPromise() {
-      return 'p-1';
-    },
     fulfillToData(result, data, slots) {
       log.push({ result, data, slots });
     },


### PR DESCRIPTION
This builds upon #120 to remove `syscall.createPromise()`. In the old scheme, vats ask the kernel for a `p-NN` promiseID when they need one (i.e. when they serialize a local Promise, or when they supply the `result` field of a `syscall.send()`).

In the new scheme, all vats maintain a vat-side `promiseIndex` counter, and send `p+NN` promiseIDs *into* the kernel. The kernel then allocates a suitable kernel promise index and maps to it in the c-list.

This doesn't necessarily get us closer to pipelining, but it does shrink the syscall API surface, and removes the last syscall that actually returns a value. This will help with #127 (transactional turns). And it enables one particular pipelining case, where a vat might choose to use an inbound result promiseID (arriving in `dispatch.deliver()`) as the outbound result in a `syscall.send()` (instead of allocating a new promise and forwarding the previous result to the new one). I think @dtribble said there's an important performance benefit to this case, some user-level operation that hits it frequently so we should avoid the allocation if possible, but I don't yet know what vat-code could prompt it.

This is the second phase of #88. The next phase will actually enable pipelining by changing the way the kernel run-queue works. We'll do a more systematic review of the whole thing before landing any of the phases.
