### PR TITLE
change some tests into importable modules, to test under XS

### DIFF
--- a/test/test-kernel.js
+++ b/test/test-kernel.js
@@ -5,1047 +5,1053 @@ import buildKernel from '../src/kernel/index';
 import { makeVatSlot } from '../src/parseVatSlots';
 import { checkKT } from './util';
 
-function checkPromises(t, kernel, expected) {
-  // extract the kernel promise table and assert that the contents match the
-  // expected list. This sorts on the promise ID, then does a t.deepEqual
-  function comparePromiseIDs(a, b) {
-    return a.id - b.id;
+export default function runTests() {
+  function checkPromises(t, kernel, expected) {
+    // extract the kernel promise table and assert that the contents match the
+    // expected list. This sorts on the promise ID, then does a t.deepEqual
+    function comparePromiseIDs(a, b) {
+      return a.id - b.id;
+    }
+
+    const got = Array.from(kernel.dump().promises);
+    got.sort(comparePromiseIDs);
+    expected = Array.from(expected);
+    expected.sort(comparePromiseIDs);
+    t.deepEqual(got, expected);
   }
 
-  const got = Array.from(kernel.dump().promises);
-  got.sort(comparePromiseIDs);
-  expected = Array.from(expected);
-  expected.sort(comparePromiseIDs);
-  t.deepEqual(got, expected);
-}
-
-function emptySetup(_syscall) {
-  function deliver() {}
-  return { deliver };
-}
-
-test('build kernel', async t => {
-  const kernel = buildKernel({ setImmediate });
-  await kernel.start(); // empty queue
-  const data = kernel.dump();
-  t.deepEqual(data.vatTables, []);
-  t.deepEqual(data.kernelTable, []);
-  t.end();
-});
-
-test('simple call', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-  function setup1(syscall, state, helpers) {
-    function deliver(facetID, method, argsString, slots) {
-      log.push([facetID, method, argsString, slots]);
-      helpers.log(JSON.stringify({ facetID, method, argsString, slots }));
-    }
+  function emptySetup(_syscall) {
+    function deliver() {}
     return { deliver };
   }
-  kernel.addGenesisVat('vat1', setup1);
-  await kernel.start();
-  let data = kernel.dump();
-  t.deepEqual(data.vatTables, [{ vatID: 'vat1', state: { transcript: [] } }]);
-  t.deepEqual(data.kernelTable, []);
-  t.deepEqual(data.log, []);
-  t.deepEqual(log, []);
 
-  kernel.queueToExport('vat1', 'o+1', 'foo', 'args');
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'send',
-      target: 'ko20',
-      msg: {
-        method: 'foo',
-        argsString: 'args',
-        slots: [],
-        result: null,
-      },
-    },
-  ]);
-  t.deepEqual(log, []);
-  await kernel.run();
-  t.deepEqual(log, [['o+1', 'foo', 'args', []]]);
-
-  data = kernel.dump();
-  t.equal(data.log.length, 1);
-  t.deepEqual(JSON.parse(data.log[0]), {
-    facetID: 'o+1',
-    method: 'foo',
-    argsString: 'args',
-    slots: [],
+  test('build kernel', async t => {
+    const kernel = buildKernel({ setImmediate });
+    await kernel.start(); // empty queue
+    const data = kernel.dump();
+    t.deepEqual(data.vatTables, []);
+    t.deepEqual(data.kernelTable, []);
+    t.end();
   });
 
-  t.end();
-});
-
-test('map inbound', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-  function setup1(_syscall) {
-    function deliver(facetID, method, argsString, slots) {
-      log.push([facetID, method, argsString, slots]);
+  test('simple call', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
+    function setup1(syscall, state, helpers) {
+      function deliver(facetID, method, argsString, slots) {
+        log.push([facetID, method, argsString, slots]);
+        helpers.log(JSON.stringify({ facetID, method, argsString, slots }));
+      }
+      return { deliver };
     }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vat1', setup1);
-  kernel.addGenesisVat('vat2', setup1);
-  await kernel.start();
-  const data = kernel.dump();
-  t.deepEqual(data.vatTables, [
-    { vatID: 'vat1', state: { transcript: [] } },
-    { vatID: 'vat2', state: { transcript: [] } },
-  ]);
-  t.deepEqual(data.kernelTable, []);
-  t.deepEqual(log, []);
+    kernel.addGenesisVat('vat1', setup1);
+    await kernel.start();
+    let data = kernel.dump();
+    t.deepEqual(data.vatTables, [{ vatID: 'vat1', state: { transcript: [] } }]);
+    t.deepEqual(data.kernelTable, []);
+    t.deepEqual(data.log, []);
+    t.deepEqual(log, []);
 
-  const koFor5 = kernel.addExport('vat1', 'o+5');
-  const koFor6 = kernel.addExport('vat2', 'o+6');
-  kernel.queueToExport('vat1', 'o+1', 'foo', 'args', [koFor5, koFor6]);
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'send',
-      target: 'ko22',
-      msg: {
-        argsString: 'args',
-        result: null,
-        method: 'foo',
-        slots: [koFor5, koFor6],
+    kernel.queueToExport('vat1', 'o+1', 'foo', 'args');
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'send',
+        target: 'ko20',
+        msg: {
+          method: 'foo',
+          argsString: 'args',
+          slots: [],
+          result: null,
+        },
       },
-    },
-  ]);
-  t.deepEqual(log, []);
-  await kernel.run();
-  t.deepEqual(log, [['o+1', 'foo', 'args', ['o+5', 'o-50']]]);
-  t.deepEqual(kernel.dump().kernelTable, [
-    [koFor5, 'vat1', 'o+5'],
-    [koFor6, 'vat1', 'o-50'],
-    [koFor6, 'vat2', 'o+6'],
-    ['ko22', 'vat1', 'o+1'],
-  ]);
+    ]);
+    t.deepEqual(log, []);
+    await kernel.run();
+    t.deepEqual(log, [['o+1', 'foo', 'args', []]]);
 
-  t.end();
-});
+    data = kernel.dump();
+    t.equal(data.log.length, 1);
+    t.deepEqual(JSON.parse(data.log[0]), {
+      facetID: 'o+1',
+      method: 'foo',
+      argsString: 'args',
+      slots: [],
+    });
 
-test('addImport', async t => {
-  const kernel = buildKernel({ setImmediate });
-  function setup(_syscall) {
-    function deliver(_facetID, _method, _argsString, _slots) {}
-    return { deliver };
-  }
-  kernel.addGenesisVat('vat1', setup);
-  kernel.addGenesisVat('vat2', setup);
-  await kernel.start();
+    t.end();
+  });
 
-  const slot = kernel.addImport('vat1', kernel.addExport('vat2', 'o+5'));
-  t.deepEqual(slot, 'o-50'); // first import
-  t.deepEqual(kernel.dump().kernelTable, [
-    ['ko20', 'vat1', 'o-50'],
-    ['ko20', 'vat2', 'o+5'],
-  ]);
-  t.end();
-});
-
-test('outbound call', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-  let v1tovat25;
-  const p7 = 'p+7';
-
-  function setup1(syscall) {
-    let nextPromiseIndex = 5;
-    function allocatePromise() {
-      const index = nextPromiseIndex;
-      nextPromiseIndex += 1;
-      return makeVatSlot('promise', true, index);
+  test('map inbound', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
+    function setup1(_syscall) {
+      function deliver(facetID, method, argsString, slots) {
+        log.push([facetID, method, argsString, slots]);
+      }
+      return { deliver };
     }
-    function deliver(facetID, method, argsString, slots) {
-      // console.log(`d1/${facetID} called`);
-      log.push(['d1', facetID, method, argsString, slots]);
-      const pid = allocatePromise();
-      syscall.send(v1tovat25, 'bar', 'bargs', [v1tovat25, 'o+7', p7], pid);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vat1', setup1);
+    kernel.addGenesisVat('vat1', setup1);
+    kernel.addGenesisVat('vat2', setup1);
+    await kernel.start();
+    const data = kernel.dump();
+    t.deepEqual(data.vatTables, [
+      { vatID: 'vat1', state: { transcript: [] } },
+      { vatID: 'vat2', state: { transcript: [] } },
+    ]);
+    t.deepEqual(data.kernelTable, []);
+    t.deepEqual(log, []);
 
-  function setup2(_syscall) {
-    function deliver(facetID, method, argsString, slots) {
-      // console.log(`d2/${facetID} called`);
-      log.push(['d2', facetID, method, argsString, slots]);
-      log.push(['d2 promises', kernel.dump().promises]);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vat2', setup2);
-  await kernel.start();
-
-  const t1 = kernel.addExport('vat1', 'o+1');
-  const vat2Obj5 = kernel.addExport('vat2', 'o+5');
-  v1tovat25 = kernel.addImport('vat1', vat2Obj5);
-  t.deepEqual(v1tovat25, 'o-50'); // first allocation
-
-  const data = kernel.dump();
-  t.deepEqual(data.vatTables, [
-    { vatID: 'vat1', state: { transcript: [] } },
-    { vatID: 'vat2', state: { transcript: [] } },
-  ]);
-
-  const kt = [
-    [t1, 'vat1', 'o+1'],
-    ['ko21', 'vat1', v1tovat25],
-    ['ko21', 'vat2', 'o+5'],
-  ];
-  checkKT(t, kernel, kt);
-  t.deepEqual(log, []);
-
-  // o1!foo(args)
-  kernel.queueToExport('vat1', 'o+1', 'foo', 'args');
-  t.deepEqual(log, []);
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'send',
-      target: t1,
-      msg: {
-        argsString: 'args',
-        result: null,
-        method: 'foo',
-        slots: [],
+    const koFor5 = kernel.addExport('vat1', 'o+5');
+    const koFor6 = kernel.addExport('vat2', 'o+6');
+    kernel.queueToExport('vat1', 'o+1', 'foo', 'args', [koFor5, koFor6]);
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'send',
+        target: 'ko22',
+        msg: {
+          argsString: 'args',
+          result: null,
+          method: 'foo',
+          slots: [koFor5, koFor6],
+        },
       },
-    },
-  ]);
+    ]);
+    t.deepEqual(log, []);
+    await kernel.run();
+    t.deepEqual(log, [['o+1', 'foo', 'args', ['o+5', 'o-50']]]);
+    t.deepEqual(kernel.dump().kernelTable, [
+      [koFor5, 'vat1', 'o+5'],
+      [koFor6, 'vat1', 'o-50'],
+      [koFor6, 'vat2', 'o+6'],
+      ['ko22', 'vat1', 'o+1'],
+    ]);
 
-  await kernel.step();
-  // that queues pid=o2!bar(o2, o7, p7)
+    t.end();
+  });
 
-  t.deepEqual(log.shift(), ['d1', 'o+1', 'foo', 'args', []]);
-  t.deepEqual(log, []);
+  test('addImport', async t => {
+    const kernel = buildKernel({ setImmediate });
+    function setup(_syscall) {
+      function deliver(_facetID, _method, _argsString, _slots) {}
+      return { deliver };
+    }
+    kernel.addGenesisVat('vat1', setup);
+    kernel.addGenesisVat('vat2', setup);
+    await kernel.start();
 
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'send',
-      target: vat2Obj5,
-      msg: {
-        method: 'bar',
-        argsString: 'bargs',
-        slots: [vat2Obj5, 'ko22', 'kp40'],
-        result: 'kp41',
+    const slot = kernel.addImport('vat1', kernel.addExport('vat2', 'o+5'));
+    t.deepEqual(slot, 'o-50'); // first import
+    t.deepEqual(kernel.dump().kernelTable, [
+      ['ko20', 'vat1', 'o-50'],
+      ['ko20', 'vat2', 'o+5'],
+    ]);
+    t.end();
+  });
+
+  test('outbound call', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
+    let v1tovat25;
+    const p7 = 'p+7';
+
+    function setup1(syscall) {
+      let nextPromiseIndex = 5;
+      function allocatePromise() {
+        const index = nextPromiseIndex;
+        nextPromiseIndex += 1;
+        return makeVatSlot('promise', true, index);
+      }
+      function deliver(facetID, method, argsString, slots) {
+        // console.log(`d1/${facetID} called`);
+        log.push(['d1', facetID, method, argsString, slots]);
+        const pid = allocatePromise();
+        syscall.send(v1tovat25, 'bar', 'bargs', [v1tovat25, 'o+7', p7], pid);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vat1', setup1);
+
+    function setup2(_syscall) {
+      function deliver(facetID, method, argsString, slots) {
+        // console.log(`d2/${facetID} called`);
+        log.push(['d2', facetID, method, argsString, slots]);
+        log.push(['d2 promises', kernel.dump().promises]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vat2', setup2);
+    await kernel.start();
+
+    const t1 = kernel.addExport('vat1', 'o+1');
+    const vat2Obj5 = kernel.addExport('vat2', 'o+5');
+    v1tovat25 = kernel.addImport('vat1', vat2Obj5);
+    t.deepEqual(v1tovat25, 'o-50'); // first allocation
+
+    const data = kernel.dump();
+    t.deepEqual(data.vatTables, [
+      { vatID: 'vat1', state: { transcript: [] } },
+      { vatID: 'vat2', state: { transcript: [] } },
+    ]);
+
+    const kt = [
+      [t1, 'vat1', 'o+1'],
+      ['ko21', 'vat1', v1tovat25],
+      ['ko21', 'vat2', 'o+5'],
+    ];
+    checkKT(t, kernel, kt);
+    t.deepEqual(log, []);
+
+    // o1!foo(args)
+    kernel.queueToExport('vat1', 'o+1', 'foo', 'args');
+    t.deepEqual(log, []);
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'send',
+        target: t1,
+        msg: {
+          argsString: 'args',
+          result: null,
+          method: 'foo',
+          slots: [],
+        },
       },
-    },
-  ]);
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: 'kp40',
-      state: 'unresolved',
-      decider: 'vat1',
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: 'kp41',
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-  ]);
+    ]);
 
-  kt.push(['ko22', 'vat1', 'o+7']);
-  kt.push(['kp40', 'vat1', p7]);
-  kt.push(['kp41', 'vat1', 'p+5']);
-  checkKT(t, kernel, kt);
+    await kernel.step();
+    // that queues pid=o2!bar(o2, o7, p7)
 
-  await kernel.step();
-  t.deepEqual(log, [
-    // todo: check result
-    ['d2', 'o+5', 'bar', 'bargs', ['o+5', 'o-50', 'p-60']],
-    [
-      'd2 promises',
+    t.deepEqual(log.shift(), ['d1', 'o+1', 'foo', 'args', []]);
+    t.deepEqual(log, []);
+
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'send',
+        target: vat2Obj5,
+        msg: {
+          method: 'bar',
+          argsString: 'bargs',
+          slots: [vat2Obj5, 'ko22', 'kp40'],
+          result: 'kp41',
+        },
+      },
+    ]);
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: 'kp40',
+        state: 'unresolved',
+        decider: 'vat1',
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: 'kp41',
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+    ]);
+
+    kt.push(['ko22', 'vat1', 'o+7']);
+    kt.push(['kp40', 'vat1', p7]);
+    kt.push(['kp41', 'vat1', 'p+5']);
+    checkKT(t, kernel, kt);
+
+    await kernel.step();
+    t.deepEqual(log, [
+      // todo: check result
+      ['d2', 'o+5', 'bar', 'bargs', ['o+5', 'o-50', 'p-60']],
       [
-        {
-          id: 'kp40',
-          state: 'unresolved',
-          decider: 'vat1',
-          subscribers: [],
-          queue: [],
-        },
-        {
-          id: 'kp41',
-          state: 'unresolved',
-          decider: 'vat2',
-          subscribers: [],
-          queue: [],
-        },
+        'd2 promises',
+        [
+          {
+            id: 'kp40',
+            state: 'unresolved',
+            decider: 'vat1',
+            subscribers: [],
+            queue: [],
+          },
+          {
+            id: 'kp41',
+            state: 'unresolved',
+            decider: 'vat2',
+            subscribers: [],
+            queue: [],
+          },
+        ],
       ],
-    ],
-  ]);
+    ]);
 
-  kt.push(['ko22', 'vat2', 'o-50']);
-  kt.push(['kp41', 'vat2', 'p-61']);
-  kt.push(['kp40', 'vat2', 'p-60']);
-  checkKT(t, kernel, kt);
+    kt.push(['ko22', 'vat2', 'o-50']);
+    kt.push(['kp41', 'vat2', 'p-61']);
+    kt.push(['kp40', 'vat2', 'p-60']);
+    checkKT(t, kernel, kt);
 
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: 'kp40',
-      state: 'unresolved',
-      decider: 'vat1',
-      // Sending a promise from vat1 to vat2 doesn't cause vat2 to be
-      // subscribed unless they want it. Liveslots will always subscribe,
-      // because we don't have enough hooks into Promises to detect a
-      // .then(), but non-liveslots vats don't have to.
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: 'kp41',
-      state: 'unresolved',
-      decider: 'vat2',
-      subscribers: [],
-      queue: [],
-    },
-  ]);
-
-  t.end();
-});
-
-test('three-party', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-  let bobForA;
-  let carolForA;
-
-  function setupA(syscall) {
-    let nextPromiseIndex = 5;
-    function allocatePromise() {
-      const index = nextPromiseIndex;
-      nextPromiseIndex += 1;
-      return makeVatSlot('promise', true, index);
-    }
-    function deliver(facetID, method, argsString, slots) {
-      console.log(`vatA/${facetID} called`);
-      log.push(['vatA', facetID, method, argsString, slots]);
-      const pid = allocatePromise();
-      syscall.send(bobForA, 'intro', 'bargs', [carolForA], pid);
-      log.push(['vatA', 'promiseID', pid]);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatA', setupA);
-
-  function setupB(_syscall) {
-    function deliver(facetID, method, argsString, slots) {
-      console.log(`vatB/${facetID} called`);
-      log.push(['vatB', facetID, method, argsString, slots]);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatB', setupB);
-
-  function setupC(_syscall) {
-    function deliver(facetID, method, argsString, slots) {
-      log.push(['vatC', facetID, method, argsString, slots]);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatC', setupC);
-
-  await kernel.start();
-
-  const alice = kernel.addExport('vatA', 'o+4');
-  const bob = kernel.addExport('vatB', 'o+5');
-  const carol = kernel.addExport('vatC', 'o+6');
-
-  bobForA = kernel.addImport('vatA', bob);
-  carolForA = kernel.addImport('vatA', carol);
-
-  // do an extra allocation to make sure we aren't confusing the indices
-  const extraP = 'p+99';
-  const ap = kernel.addExport('vatA', extraP);
-
-  const data = kernel.dump();
-  t.deepEqual(data.vatTables, [
-    { vatID: 'vatA', state: { transcript: [] } },
-    { vatID: 'vatB', state: { transcript: [] } },
-    { vatID: 'vatC', state: { transcript: [] } },
-  ]);
-  const kt = [
-    [alice, 'vatA', 'o+4'],
-    [bob, 'vatA', bobForA],
-    [bob, 'vatB', 'o+5'],
-    [carol, 'vatA', carolForA],
-    [carol, 'vatC', 'o+6'],
-    [ap, 'vatA', extraP],
-  ];
-  checkKT(t, kernel, kt);
-  t.deepEqual(log, []);
-
-  kernel.queueToExport('vatA', 'o+4', 'foo', 'args');
-  await kernel.step();
-
-  t.deepEqual(log.shift(), ['vatA', 'o+4', 'foo', 'args', []]);
-  t.deepEqual(log.shift(), ['vatA', 'promiseID', 'p+5']);
-  t.deepEqual(log, []);
-
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'send',
-      target: bob,
-      msg: {
-        method: 'intro',
-        argsString: 'bargs',
-        slots: [carol],
-        result: 'kp41',
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: 'kp40',
+        state: 'unresolved',
+        decider: 'vat1',
+        // Sending a promise from vat1 to vat2 doesn't cause vat2 to be
+        // subscribed unless they want it. Liveslots will always subscribe,
+        // because we don't have enough hooks into Promises to detect a
+        // .then(), but non-liveslots vats don't have to.
+        subscribers: [],
+        queue: [],
       },
-    },
-  ]);
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: ap,
+      {
+        id: 'kp41',
+        state: 'unresolved',
+        decider: 'vat2',
+        subscribers: [],
+        queue: [],
+      },
+    ]);
+
+    t.end();
+  });
+
+  test('three-party', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
+    let bobForA;
+    let carolForA;
+
+    function setupA(syscall) {
+      let nextPromiseIndex = 5;
+      function allocatePromise() {
+        const index = nextPromiseIndex;
+        nextPromiseIndex += 1;
+        return makeVatSlot('promise', true, index);
+      }
+      function deliver(facetID, method, argsString, slots) {
+        console.log(`vatA/${facetID} called`);
+        log.push(['vatA', facetID, method, argsString, slots]);
+        const pid = allocatePromise();
+        syscall.send(bobForA, 'intro', 'bargs', [carolForA], pid);
+        log.push(['vatA', 'promiseID', pid]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatA', setupA);
+
+    function setupB(_syscall) {
+      function deliver(facetID, method, argsString, slots) {
+        console.log(`vatB/${facetID} called`);
+        log.push(['vatB', facetID, method, argsString, slots]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatB', setupB);
+
+    function setupC(_syscall) {
+      function deliver(facetID, method, argsString, slots) {
+        log.push(['vatC', facetID, method, argsString, slots]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatC', setupC);
+
+    await kernel.start();
+
+    const alice = kernel.addExport('vatA', 'o+4');
+    const bob = kernel.addExport('vatB', 'o+5');
+    const carol = kernel.addExport('vatC', 'o+6');
+
+    bobForA = kernel.addImport('vatA', bob);
+    carolForA = kernel.addImport('vatA', carol);
+
+    // do an extra allocation to make sure we aren't confusing the indices
+    const extraP = 'p+99';
+    const ap = kernel.addExport('vatA', extraP);
+
+    const data = kernel.dump();
+    t.deepEqual(data.vatTables, [
+      { vatID: 'vatA', state: { transcript: [] } },
+      { vatID: 'vatB', state: { transcript: [] } },
+      { vatID: 'vatC', state: { transcript: [] } },
+    ]);
+    const kt = [
+      [alice, 'vatA', 'o+4'],
+      [bob, 'vatA', bobForA],
+      [bob, 'vatB', 'o+5'],
+      [carol, 'vatA', carolForA],
+      [carol, 'vatC', 'o+6'],
+      [ap, 'vatA', extraP],
+    ];
+    checkKT(t, kernel, kt);
+    t.deepEqual(log, []);
+
+    kernel.queueToExport('vatA', 'o+4', 'foo', 'args');
+    await kernel.step();
+
+    t.deepEqual(log.shift(), ['vatA', 'o+4', 'foo', 'args', []]);
+    t.deepEqual(log.shift(), ['vatA', 'promiseID', 'p+5']);
+    t.deepEqual(log, []);
+
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'send',
+        target: bob,
+        msg: {
+          method: 'intro',
+          argsString: 'bargs',
+          slots: [carol],
+          result: 'kp41',
+        },
+      },
+    ]);
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: ap,
+        state: 'unresolved',
+        decider: 'vatA',
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: 'kp41',
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+    ]);
+    kt.push(['kp41', 'vatA', 'p+5']);
+    checkKT(t, kernel, kt);
+
+    await kernel.step();
+    t.deepEqual(log, [['vatB', 'o+5', 'intro', 'bargs', ['o-50']]]);
+    kt.push([carol, 'vatB', 'o-50']);
+    kt.push(['kp41', 'vatB', 'p-60']);
+    checkKT(t, kernel, kt);
+
+    t.end();
+  });
+
+  test('transfer promise', async t => {
+    const kernel = buildKernel({ setImmediate });
+    let syscallA;
+    const logA = [];
+    function setupA(syscall) {
+      syscallA = syscall;
+      function deliver(facetID, method, argsString, slots) {
+        logA.push([facetID, method, argsString, slots]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatA', setupA);
+
+    let syscallB;
+    const logB = [];
+    function setupB(syscall) {
+      syscallB = syscall;
+      function deliver(facetID, method, argsString, slots) {
+        logB.push([facetID, method, argsString, slots]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatB', setupB);
+
+    await kernel.start();
+
+    const alice = kernel.addExport('vatA', 'o+6');
+    const bob = kernel.addExport('vatB', 'o+5');
+
+    const B = kernel.addImport('vatA', bob);
+    const A = kernel.addImport('vatB', alice);
+
+    // we send pr1
+    const pr1 = 'p+6';
+
+    const kt = [
+      ['ko20', 'vatA', 'o+6'],
+      ['ko20', 'vatB', 'o-50'],
+      ['ko21', 'vatA', 'o-50'],
+      ['ko21', 'vatB', 'o+5'],
+    ];
+    checkKT(t, kernel, kt);
+    const kp = [];
+    checkPromises(t, kernel, kp);
+
+    // sending a promise should arrive as a promise
+    syscallA.send(B, 'foo1', 'args', [pr1]);
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'send',
+        target: bob,
+        msg: {
+          method: 'foo1',
+          argsString: 'args',
+          slots: ['kp40'],
+          result: undefined,
+        },
+      },
+    ]);
+    kt.push(['kp40', 'vatA', pr1]);
+    checkKT(t, kernel, kt);
+    kp.push({
+      id: 'kp40',
       state: 'unresolved',
       decider: 'vatA',
       subscribers: [],
       queue: [],
-    },
-    {
-      id: 'kp41',
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-  ]);
-  kt.push(['kp41', 'vatA', 'p+5']);
-  checkKT(t, kernel, kt);
+    });
+    checkPromises(t, kernel, kp);
+    await kernel.run();
+    t.deepEqual(logB.shift(), ['o+5', 'foo1', 'args', ['p-60']]);
+    t.deepEqual(logB, []);
+    kt.push(['kp40', 'vatB', 'p-60']); // pr1 for B
+    checkKT(t, kernel, kt);
 
-  await kernel.step();
-  t.deepEqual(log, [['vatB', 'o+5', 'intro', 'bargs', ['o-50']]]);
-  kt.push([carol, 'vatB', 'o-50']);
-  kt.push(['kp41', 'vatB', 'p-60']);
-  checkKT(t, kernel, kt);
+    // sending it a second time should arrive as the same thing
+    syscallA.send(B, 'foo2', 'args', [pr1]);
+    await kernel.run();
+    t.deepEqual(logB.shift(), ['o+5', 'foo2', 'args', ['p-60']]);
+    t.deepEqual(logB, []);
+    checkKT(t, kernel, kt);
+    checkPromises(t, kernel, kp);
 
-  t.end();
-});
+    // sending it back should arrive with the sender's index
+    syscallB.send(A, 'foo3', 'args', ['p-60']);
+    await kernel.run();
+    t.deepEqual(logA.shift(), ['o+6', 'foo3', 'args', [pr1]]);
+    t.deepEqual(logA, []);
+    checkKT(t, kernel, kt);
+    checkPromises(t, kernel, kp);
 
-test('transfer promise', async t => {
-  const kernel = buildKernel({ setImmediate });
-  let syscallA;
-  const logA = [];
-  function setupA(syscall) {
-    syscallA = syscall;
-    function deliver(facetID, method, argsString, slots) {
-      logA.push([facetID, method, argsString, slots]);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatA', setupA);
+    // sending it back a second time should arrive as the same thing
+    syscallB.send(A, 'foo4', 'args', ['p-60']);
+    await kernel.run();
+    t.deepEqual(logA.shift(), ['o+6', 'foo4', 'args', [pr1]]);
+    t.deepEqual(logA, []);
+    checkPromises(t, kernel, kp);
+    checkKT(t, kernel, kt);
 
-  let syscallB;
-  const logB = [];
-  function setupB(syscall) {
-    syscallB = syscall;
-    function deliver(facetID, method, argsString, slots) {
-      logB.push([facetID, method, argsString, slots]);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatB', setupB);
-
-  await kernel.start();
-
-  const alice = kernel.addExport('vatA', 'o+6');
-  const bob = kernel.addExport('vatB', 'o+5');
-
-  const B = kernel.addImport('vatA', bob);
-  const A = kernel.addImport('vatB', alice);
-
-  // we send pr1
-  const pr1 = 'p+6';
-
-  const kt = [
-    ['ko20', 'vatA', 'o+6'],
-    ['ko20', 'vatB', 'o-50'],
-    ['ko21', 'vatA', 'o-50'],
-    ['ko21', 'vatB', 'o+5'],
-  ];
-  checkKT(t, kernel, kt);
-  const kp = [];
-  checkPromises(t, kernel, kp);
-
-  // sending a promise should arrive as a promise
-  syscallA.send(B, 'foo1', 'args', [pr1]);
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'send',
-      target: bob,
-      msg: {
-        method: 'foo1',
-        argsString: 'args',
-        slots: ['kp40'],
-        result: undefined,
-      },
-    },
-  ]);
-  kt.push(['kp40', 'vatA', pr1]);
-  checkKT(t, kernel, kt);
-  kp.push({
-    id: 'kp40',
-    state: 'unresolved',
-    decider: 'vatA',
-    subscribers: [],
-    queue: [],
+    t.end();
   });
-  checkPromises(t, kernel, kp);
-  await kernel.run();
-  t.deepEqual(logB.shift(), ['o+5', 'foo1', 'args', ['p-60']]);
-  t.deepEqual(logB, []);
-  kt.push(['kp40', 'vatB', 'p-60']); // pr1 for B
-  checkKT(t, kernel, kt);
 
-  // sending it a second time should arrive as the same thing
-  syscallA.send(B, 'foo2', 'args', [pr1]);
-  await kernel.run();
-  t.deepEqual(logB.shift(), ['o+5', 'foo2', 'args', ['p-60']]);
-  t.deepEqual(logB, []);
-  checkKT(t, kernel, kt);
-  checkPromises(t, kernel, kp);
-
-  // sending it back should arrive with the sender's index
-  syscallB.send(A, 'foo3', 'args', ['p-60']);
-  await kernel.run();
-  t.deepEqual(logA.shift(), ['o+6', 'foo3', 'args', [pr1]]);
-  t.deepEqual(logA, []);
-  checkKT(t, kernel, kt);
-  checkPromises(t, kernel, kp);
-
-  // sending it back a second time should arrive as the same thing
-  syscallB.send(A, 'foo4', 'args', ['p-60']);
-  await kernel.run();
-  t.deepEqual(logA.shift(), ['o+6', 'foo4', 'args', [pr1]]);
-  t.deepEqual(logA, []);
-  checkPromises(t, kernel, kp);
-  checkKT(t, kernel, kt);
-
-  t.end();
-});
-
-test('subscribe to promise', async t => {
-  const kernel = buildKernel({ setImmediate });
-  let syscall;
-  const log = [];
-  function setup(s) {
-    syscall = s;
-    function deliver(facetID, method, argsString, slots) {
-      log.push(['deliver', facetID, method, argsString, slots]);
-    }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vat1', setup);
-  kernel.addGenesisVat('vat2', emptySetup);
-
-  await kernel.start();
-
-  const kp = kernel.addExport('vat2', 'p+5');
-  const pr = kernel.addImport('vat1', kp);
-  t.deepEqual(pr, 'p-60');
-  t.deepEqual(kernel.dump().kernelTable, [
-    [kp, 'vat1', pr],
-    [kp, 'vat2', 'p+5'],
-  ]);
-
-  syscall.subscribe(pr);
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: kp,
-      state: 'unresolved',
-      decider: 'vat2',
-      subscribers: ['vat1'],
-      queue: [],
-    },
-  ]);
-  t.deepEqual(kernel.dump().runQueue, []);
-  t.deepEqual(log, []);
-
-  t.end();
-});
-
-test('promise resolveToData', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-
-  let syscallA;
-  function setupA(s) {
-    syscallA = s;
-    function deliver() {}
-    function notifyFulfillToData(promiseID, fulfillData, slots) {
-      log.push(['notify', promiseID, fulfillData, slots]);
-    }
-    return { deliver, notifyFulfillToData };
-  }
-  kernel.addGenesisVat('vatA', setupA);
-
-  let syscallB;
-  function setupB(s) {
-    syscallB = s;
-    function deliver() {}
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatB', setupB);
-  await kernel.start();
-
-  const aliceForA = 'o+6';
-  const pForB = 'p+5';
-  const pForKernel = kernel.addExport('vatB', pForB);
-  const pForA = kernel.addImport('vatA', pForKernel);
-  t.deepEqual(kernel.dump().kernelTable, [
-    [pForKernel, 'vatA', pForA],
-    [pForKernel, 'vatB', pForB],
-  ]);
-
-  syscallA.subscribe(pForA);
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: pForKernel,
-      state: 'unresolved',
-      decider: 'vatB',
-      subscribers: ['vatA'],
-      queue: [],
-    },
-  ]);
-
-  syscallB.fulfillToData(pForB, 'args', [aliceForA]);
-  // this causes a notifyFulfillToData message to be queued
-  t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'notify',
-      vatID: 'vatA',
-      kpid: pForKernel,
-    },
-  ]);
-
-  await kernel.step();
-  // the kernelPromiseID gets mapped back to the vat PromiseID
-  t.deepEqual(log.shift(), ['notify', pForA, 'args', ['o-50']]);
-  t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: pForKernel,
-      fulfillData: 'args',
-      fulfillSlots: ['ko20'],
-      state: 'fulfilledToData',
-    },
-  ]);
-  t.deepEqual(kernel.dump().runQueue, []);
-
-  t.end();
-});
-
-test('promise resolveToPresence', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-
-  let syscallA;
-  function setupA(s) {
-    syscallA = s;
-    function deliver() {}
-    function notifyFulfillToPresence(promiseID, slot) {
-      log.push(['notify', promiseID, slot]);
-    }
-    return { deliver, notifyFulfillToPresence };
-  }
-  kernel.addGenesisVat('vatA', setupA);
-
-  let syscallB;
-  function setupB(s) {
-    syscallB = s;
-    function deliver() {}
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatB', setupB);
-  await kernel.start();
-
-  const bobForB = 'o+6';
-  const bobForKernel = kernel.addExport('vatB', 'o+6');
-  const bobForA = kernel.addImport('vatA', bobForKernel);
-
-  const pForB = 'p+5';
-  const pForKernel = kernel.addExport('vatB', 'p+5');
-  const pForA = kernel.addImport('vatA', pForKernel);
-  const kt = [
-    [bobForKernel, 'vatB', bobForB],
-    [bobForKernel, 'vatA', bobForA],
-    [pForKernel, 'vatA', pForA],
-    [pForKernel, 'vatB', pForB],
-  ];
-  checkKT(t, kernel, kt);
-
-  syscallA.subscribe(pForA);
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: pForKernel,
-      state: 'unresolved',
-      decider: 'vatB',
-      subscribers: ['vatA'],
-      queue: [],
-    },
-  ]);
-
-  syscallB.fulfillToPresence(pForB, bobForB);
-  t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'notify',
-      vatID: 'vatA',
-      kpid: pForKernel,
-    },
-  ]);
-
-  await kernel.step();
-  t.deepEqual(log.shift(), ['notify', pForA, bobForA]);
-  t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: pForKernel,
-      fulfillSlot: bobForKernel,
-      state: 'fulfilledToPresence',
-    },
-  ]);
-  t.deepEqual(kernel.dump().runQueue, []);
-  t.end();
-});
-
-test('promise reject', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-
-  let syscallA;
-  function setupA(s) {
-    syscallA = s;
-    function deliver() {}
-    function notifyReject(promiseID, rejectData, slots) {
-      log.push(['notify', promiseID, rejectData, slots]);
-    }
-    return { deliver, notifyReject };
-  }
-  kernel.addGenesisVat('vatA', setupA);
-
-  let syscallB;
-  function setupB(s) {
-    syscallB = s;
-    function deliver() {}
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatB', setupB);
-  await kernel.start();
-
-  const aliceForA = 'o+6';
-  const pForB = 'p+5';
-  const pForKernel = kernel.addExport('vatB', pForB);
-  const pForA = kernel.addImport('vatA', pForKernel);
-  t.deepEqual(kernel.dump().kernelTable, [
-    [pForKernel, 'vatA', pForA],
-    [pForKernel, 'vatB', pForB],
-  ]);
-
-  syscallA.subscribe(pForA);
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: pForKernel,
-      state: 'unresolved',
-      decider: 'vatB',
-      subscribers: ['vatA'],
-      queue: [],
-    },
-  ]);
-
-  syscallB.reject(pForB, 'args', [aliceForA]);
-  // this causes a notifyFulfillToData message to be queued
-  t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().runQueue, [
-    {
-      type: 'notify',
-      vatID: 'vatA',
-      kpid: pForKernel,
-    },
-  ]);
-
-  await kernel.step();
-  // the kernelPromiseID gets mapped back to the vat PromiseID
-  t.deepEqual(log.shift(), ['notify', pForA, 'args', ['o-50']]);
-  t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: pForKernel,
-      rejectData: 'args',
-      rejectSlots: ['ko20'],
-      state: 'rejected',
-    },
-  ]);
-  t.deepEqual(kernel.dump().runQueue, []);
-
-  t.end();
-});
-
-test('transcript', async t => {
-  const aliceForAlice = 'o+1';
-  const kernel = buildKernel({ setImmediate });
-  function setup(syscall, _state) {
-    function deliver(facetID, _method, _argsString, slots) {
-      if (facetID === aliceForAlice) {
-        syscall.send(slots[1], 'foo', 'fooarg', [], 'p+5');
+  test('subscribe to promise', async t => {
+    const kernel = buildKernel({ setImmediate });
+    let syscall;
+    const log = [];
+    function setup(s) {
+      syscall = s;
+      function deliver(facetID, method, argsString, slots) {
+        log.push(['deliver', facetID, method, argsString, slots]);
       }
+      return { deliver };
     }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatA', setup);
-  kernel.addGenesisVat('vatB', emptySetup);
-  await kernel.start();
+    kernel.addGenesisVat('vat1', setup);
+    kernel.addGenesisVat('vat2', emptySetup);
 
-  const alice = kernel.addExport('vatA', aliceForAlice);
-  const bob = kernel.addExport('vatB', 'o+2');
-  const bobForAlice = kernel.addImport('vatA', bob);
+    await kernel.start();
 
-  kernel.queueToExport('vatA', aliceForAlice, 'store', 'args string', [
-    alice,
-    bob,
-  ]);
-  await kernel.step();
+    const kp = kernel.addExport('vat2', 'p+5');
+    const pr = kernel.addImport('vat1', kp);
+    t.deepEqual(pr, 'p-60');
+    t.deepEqual(kernel.dump().kernelTable, [
+      [kp, 'vat1', pr],
+      [kp, 'vat2', 'p+5'],
+    ]);
 
-  // the transcript records vat-specific import/export slots
-
-  const tr = kernel.dump().vatTables[0].state.transcript;
-  t.equal(tr.length, 1);
-  t.deepEqual(tr[0], {
-    d: [
-      'deliver',
-      aliceForAlice,
-      'store',
-      'args string',
-      [aliceForAlice, bobForAlice],
-      undefined,
-    ],
-    syscalls: [
+    syscall.subscribe(pr);
+    t.deepEqual(kernel.dump().promises, [
       {
-        d: ['send', bobForAlice, 'foo', 'fooarg', [], 'p+5'],
-        response: undefined,
+        id: kp,
+        state: 'unresolved',
+        decider: 'vat2',
+        subscribers: ['vat1'],
+        queue: [],
       },
-    ],
+    ]);
+    t.deepEqual(kernel.dump().runQueue, []);
+    t.deepEqual(log, []);
+
+    t.end();
   });
 
-  t.end();
-});
+  test('promise resolveToData', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
 
-// p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); no pipelining. p1 will have a
-// decider but p2 gets queued in p1 (not pipelined to vat-with-x) so p2 won't
-// have a decider. Make sure p3 gets queued in p2 rather than exploding.
-
-test('non-pipelined promise queueing', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
-
-  let syscall;
-  function setupA(s) {
-    syscall = s;
-    function deliver() {}
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatA', setupA);
-
-  function setupB(_s) {
-    function deliver(target, method, argsString, slots, result) {
-      log.push([target, method, argsString, slots, result]);
+    let syscallA;
+    function setupA(s) {
+      syscallA = s;
+      function deliver() {}
+      function notifyFulfillToData(promiseID, fulfillData, slots) {
+        log.push(['notify', promiseID, fulfillData, slots]);
+      }
+      return { deliver, notifyFulfillToData };
     }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatB', setupB);
-  await kernel.start();
+    kernel.addGenesisVat('vatA', setupA);
 
-  const bobForB = 'o+6';
-  const bobForKernel = kernel.addExport('vatB', bobForB);
-  const bobForA = kernel.addImport('vatA', bobForKernel);
+    let syscallB;
+    function setupB(s) {
+      syscallB = s;
+      function deliver() {}
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatB', setupB);
+    await kernel.start();
 
-  const p1ForA = 'p+1';
-  syscall.send(bobForA, 'foo', 'fooargs', [], p1ForA);
-  const p1ForKernel = kernel.addExport('vatA', p1ForA);
+    const aliceForA = 'o+6';
+    const pForB = 'p+5';
+    const pForKernel = kernel.addExport('vatB', pForB);
+    const pForA = kernel.addImport('vatA', pForKernel);
+    t.deepEqual(kernel.dump().kernelTable, [
+      [pForKernel, 'vatA', pForA],
+      [pForKernel, 'vatB', pForB],
+    ]);
 
-  const p2ForA = 'p+2';
-  syscall.send(p1ForA, 'bar', 'barargs', [], p2ForA);
-  const p2ForKernel = kernel.addExport('vatA', p2ForA);
+    syscallA.subscribe(pForA);
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: pForKernel,
+        state: 'unresolved',
+        decider: 'vatB',
+        subscribers: ['vatA'],
+        queue: [],
+      },
+    ]);
 
-  const p3ForA = 'p+3';
-  syscall.send(p2ForA, 'urgh', 'urghargs', [], p3ForA);
-  const p3ForKernel = kernel.addExport('vatA', p3ForA);
+    syscallB.fulfillToData(pForB, 'args', [aliceForA]);
+    // this causes a notifyFulfillToData message to be queued
+    t.deepEqual(log, []); // no other dispatch calls
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'notify',
+        vatID: 'vatA',
+        kpid: pForKernel,
+      },
+    ]);
 
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: p1ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: p2ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: p3ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-  ]);
+    await kernel.step();
+    // the kernelPromiseID gets mapped back to the vat PromiseID
+    t.deepEqual(log.shift(), ['notify', pForA, 'args', ['o-50']]);
+    t.deepEqual(log, []); // no other dispatch calls
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: pForKernel,
+        fulfillData: 'args',
+        fulfillSlots: ['ko20'],
+        state: 'fulfilledToData',
+      },
+    ]);
+    t.deepEqual(kernel.dump().runQueue, []);
 
-  await kernel.run();
+    t.end();
+  });
 
-  const p1ForB = kernel.addImport('vatB', p1ForKernel);
-  t.deepEqual(log.shift(), [bobForB, 'foo', 'fooargs', [], p1ForB]);
-  t.deepEqual(log, []);
+  test('promise resolveToPresence', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
 
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: p1ForKernel,
-      state: 'unresolved',
-      decider: 'vatB',
-      subscribers: [],
-      queue: [
+    let syscallA;
+    function setupA(s) {
+      syscallA = s;
+      function deliver() {}
+      function notifyFulfillToPresence(promiseID, slot) {
+        log.push(['notify', promiseID, slot]);
+      }
+      return { deliver, notifyFulfillToPresence };
+    }
+    kernel.addGenesisVat('vatA', setupA);
+
+    let syscallB;
+    function setupB(s) {
+      syscallB = s;
+      function deliver() {}
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatB', setupB);
+    await kernel.start();
+
+    const bobForB = 'o+6';
+    const bobForKernel = kernel.addExport('vatB', 'o+6');
+    const bobForA = kernel.addImport('vatA', bobForKernel);
+
+    const pForB = 'p+5';
+    const pForKernel = kernel.addExport('vatB', 'p+5');
+    const pForA = kernel.addImport('vatA', pForKernel);
+    const kt = [
+      [bobForKernel, 'vatB', bobForB],
+      [bobForKernel, 'vatA', bobForA],
+      [pForKernel, 'vatA', pForA],
+      [pForKernel, 'vatB', pForB],
+    ];
+    checkKT(t, kernel, kt);
+
+    syscallA.subscribe(pForA);
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: pForKernel,
+        state: 'unresolved',
+        decider: 'vatB',
+        subscribers: ['vatA'],
+        queue: [],
+      },
+    ]);
+
+    syscallB.fulfillToPresence(pForB, bobForB);
+    t.deepEqual(log, []); // no other dispatch calls
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'notify',
+        vatID: 'vatA',
+        kpid: pForKernel,
+      },
+    ]);
+
+    await kernel.step();
+    t.deepEqual(log.shift(), ['notify', pForA, bobForA]);
+    t.deepEqual(log, []); // no other dispatch calls
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: pForKernel,
+        fulfillSlot: bobForKernel,
+        state: 'fulfilledToPresence',
+      },
+    ]);
+    t.deepEqual(kernel.dump().runQueue, []);
+    t.end();
+  });
+
+  test('promise reject', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
+
+    let syscallA;
+    function setupA(s) {
+      syscallA = s;
+      function deliver() {}
+      function notifyReject(promiseID, rejectData, slots) {
+        log.push(['notify', promiseID, rejectData, slots]);
+      }
+      return { deliver, notifyReject };
+    }
+    kernel.addGenesisVat('vatA', setupA);
+
+    let syscallB;
+    function setupB(s) {
+      syscallB = s;
+      function deliver() {}
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatB', setupB);
+    await kernel.start();
+
+    const aliceForA = 'o+6';
+    const pForB = 'p+5';
+    const pForKernel = kernel.addExport('vatB', pForB);
+    const pForA = kernel.addImport('vatA', pForKernel);
+    t.deepEqual(kernel.dump().kernelTable, [
+      [pForKernel, 'vatA', pForA],
+      [pForKernel, 'vatB', pForB],
+    ]);
+
+    syscallA.subscribe(pForA);
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: pForKernel,
+        state: 'unresolved',
+        decider: 'vatB',
+        subscribers: ['vatA'],
+        queue: [],
+      },
+    ]);
+
+    syscallB.reject(pForB, 'args', [aliceForA]);
+    // this causes a notifyFulfillToData message to be queued
+    t.deepEqual(log, []); // no other dispatch calls
+    t.deepEqual(kernel.dump().runQueue, [
+      {
+        type: 'notify',
+        vatID: 'vatA',
+        kpid: pForKernel,
+      },
+    ]);
+
+    await kernel.step();
+    // the kernelPromiseID gets mapped back to the vat PromiseID
+    t.deepEqual(log.shift(), ['notify', pForA, 'args', ['o-50']]);
+    t.deepEqual(log, []); // no other dispatch calls
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: pForKernel,
+        rejectData: 'args',
+        rejectSlots: ['ko20'],
+        state: 'rejected',
+      },
+    ]);
+    t.deepEqual(kernel.dump().runQueue, []);
+
+    t.end();
+  });
+
+  test('transcript', async t => {
+    const aliceForAlice = 'o+1';
+    const kernel = buildKernel({ setImmediate });
+    function setup(syscall, _state) {
+      function deliver(facetID, _method, _argsString, slots) {
+        if (facetID === aliceForAlice) {
+          syscall.send(slots[1], 'foo', 'fooarg', [], 'p+5');
+        }
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatA', setup);
+    kernel.addGenesisVat('vatB', emptySetup);
+    await kernel.start();
+
+    const alice = kernel.addExport('vatA', aliceForAlice);
+    const bob = kernel.addExport('vatB', 'o+2');
+    const bobForAlice = kernel.addImport('vatA', bob);
+
+    kernel.queueToExport('vatA', aliceForAlice, 'store', 'args string', [
+      alice,
+      bob,
+    ]);
+    await kernel.step();
+
+    // the transcript records vat-specific import/export slots
+
+    const tr = kernel.dump().vatTables[0].state.transcript;
+    t.equal(tr.length, 1);
+    t.deepEqual(tr[0], {
+      d: [
+        'deliver',
+        aliceForAlice,
+        'store',
+        'args string',
+        [aliceForAlice, bobForAlice],
+        undefined,
+      ],
+      syscalls: [
         {
-          method: 'bar',
-          argsString: 'barargs',
-          slots: [],
-          result: p2ForKernel,
+          d: ['send', bobForAlice, 'foo', 'fooarg', [], 'p+5'],
+          response: undefined,
         },
       ],
-    },
-    {
-      id: p2ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [
-        {
-          method: 'urgh',
-          argsString: 'urghargs',
-          slots: [],
-          result: p3ForKernel,
-        },
-      ],
-    },
-    {
-      id: p3ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-  ]);
+    });
 
-  t.end();
-});
+    t.end();
+  });
 
-// p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); with pipelining. All three should
-// get delivered to vat-with-x.
+  // p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); no pipelining. p1 will have a
+  // decider but p2 gets queued in p1 (not pipelined to vat-with-x) so p2 won't
+  // have a decider. Make sure p3 gets queued in p2 rather than exploding.
 
-test('pipelined promise queueing', async t => {
-  const kernel = buildKernel({ setImmediate });
-  const log = [];
+  test('non-pipelined promise queueing', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
 
-  let syscall;
-  function setupA(s) {
-    syscall = s;
-    function deliver() {}
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatA', setupA);
-
-  function setupB(_s) {
-    function deliver(target, method, argsString, slots, result) {
-      log.push([target, method, argsString, slots, result]);
+    let syscall;
+    function setupA(s) {
+      syscall = s;
+      function deliver() {}
+      return { deliver };
     }
-    return { deliver };
-  }
-  kernel.addGenesisVat('vatB', setupB, { enablePipelining: true });
-  await kernel.start();
+    kernel.addGenesisVat('vatA', setupA);
 
-  const bobForB = 'o+6';
-  const bobForKernel = kernel.addExport('vatB', bobForB);
-  const bobForA = kernel.addImport('vatA', bobForKernel);
+    function setupB(_s) {
+      function deliver(target, method, argsString, slots, result) {
+        log.push([target, method, argsString, slots, result]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatB', setupB);
+    await kernel.start();
 
-  const p1ForA = 'p+1';
-  syscall.send(bobForA, 'foo', 'fooargs', [], p1ForA);
-  const p1ForKernel = kernel.addExport('vatA', p1ForA);
+    const bobForB = 'o+6';
+    const bobForKernel = kernel.addExport('vatB', bobForB);
+    const bobForA = kernel.addImport('vatA', bobForKernel);
 
-  const p2ForA = 'p+2';
-  syscall.send(p1ForA, 'bar', 'barargs', [], p2ForA);
-  const p2ForKernel = kernel.addExport('vatA', p2ForA);
+    const p1ForA = 'p+1';
+    syscall.send(bobForA, 'foo', 'fooargs', [], p1ForA);
+    const p1ForKernel = kernel.addExport('vatA', p1ForA);
 
-  const p3ForA = 'p+3';
-  syscall.send(p2ForA, 'urgh', 'urghargs', [], p3ForA);
-  const p3ForKernel = kernel.addExport('vatA', p3ForA);
+    const p2ForA = 'p+2';
+    syscall.send(p1ForA, 'bar', 'barargs', [], p2ForA);
+    const p2ForKernel = kernel.addExport('vatA', p2ForA);
 
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: p1ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: p2ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: p3ForKernel,
-      state: 'unresolved',
-      decider: undefined,
-      subscribers: [],
-      queue: [],
-    },
-  ]);
+    const p3ForA = 'p+3';
+    syscall.send(p2ForA, 'urgh', 'urghargs', [], p3ForA);
+    const p3ForKernel = kernel.addExport('vatA', p3ForA);
 
-  await kernel.run();
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: p1ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: p2ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: p3ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+    ]);
 
-  const p1ForB = kernel.addImport('vatB', p1ForKernel);
-  const p2ForB = kernel.addImport('vatB', p2ForKernel);
-  const p3ForB = kernel.addImport('vatB', p3ForKernel);
-  t.deepEqual(log.shift(), [bobForB, 'foo', 'fooargs', [], p1ForB]);
-  t.deepEqual(log.shift(), [p1ForB, 'bar', 'barargs', [], p2ForB]);
-  t.deepEqual(log.shift(), [p2ForB, 'urgh', 'urghargs', [], p3ForB]);
-  t.deepEqual(log, []);
+    await kernel.run();
 
-  t.deepEqual(kernel.dump().promises, [
-    {
-      id: p1ForKernel,
-      state: 'unresolved',
-      decider: 'vatB',
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: p2ForKernel,
-      state: 'unresolved',
-      decider: 'vatB',
-      subscribers: [],
-      queue: [],
-    },
-    {
-      id: p3ForKernel,
-      state: 'unresolved',
-      decider: 'vatB',
-      subscribers: [],
-      queue: [],
-    },
-  ]);
+    const p1ForB = kernel.addImport('vatB', p1ForKernel);
+    t.deepEqual(log.shift(), [bobForB, 'foo', 'fooargs', [], p1ForB]);
+    t.deepEqual(log, []);
 
-  t.end();
-});
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: p1ForKernel,
+        state: 'unresolved',
+        decider: 'vatB',
+        subscribers: [],
+        queue: [
+          {
+            method: 'bar',
+            argsString: 'barargs',
+            slots: [],
+            result: p2ForKernel,
+          },
+        ],
+      },
+      {
+        id: p2ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [
+          {
+            method: 'urgh',
+            argsString: 'urghargs',
+            slots: [],
+            result: p3ForKernel,
+          },
+        ],
+      },
+      {
+        id: p3ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+    ]);
+
+    t.end();
+  });
+
+  // p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); with pipelining. All three should
+  // get delivered to vat-with-x.
+
+  test('pipelined promise queueing', async t => {
+    const kernel = buildKernel({ setImmediate });
+    const log = [];
+
+    let syscall;
+    function setupA(s) {
+      syscall = s;
+      function deliver() {}
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatA', setupA);
+
+    function setupB(_s) {
+      function deliver(target, method, argsString, slots, result) {
+        log.push([target, method, argsString, slots, result]);
+      }
+      return { deliver };
+    }
+    kernel.addGenesisVat('vatB', setupB, { enablePipelining: true });
+    await kernel.start();
+
+    const bobForB = 'o+6';
+    const bobForKernel = kernel.addExport('vatB', bobForB);
+    const bobForA = kernel.addImport('vatA', bobForKernel);
+
+    const p1ForA = 'p+1';
+    syscall.send(bobForA, 'foo', 'fooargs', [], p1ForA);
+    const p1ForKernel = kernel.addExport('vatA', p1ForA);
+
+    const p2ForA = 'p+2';
+    syscall.send(p1ForA, 'bar', 'barargs', [], p2ForA);
+    const p2ForKernel = kernel.addExport('vatA', p2ForA);
+
+    const p3ForA = 'p+3';
+    syscall.send(p2ForA, 'urgh', 'urghargs', [], p3ForA);
+    const p3ForKernel = kernel.addExport('vatA', p3ForA);
+
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: p1ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: p2ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: p3ForKernel,
+        state: 'unresolved',
+        decider: undefined,
+        subscribers: [],
+        queue: [],
+      },
+    ]);
+
+    await kernel.run();
+
+    const p1ForB = kernel.addImport('vatB', p1ForKernel);
+    const p2ForB = kernel.addImport('vatB', p2ForKernel);
+    const p3ForB = kernel.addImport('vatB', p3ForKernel);
+    t.deepEqual(log.shift(), [bobForB, 'foo', 'fooargs', [], p1ForB]);
+    t.deepEqual(log.shift(), [p1ForB, 'bar', 'barargs', [], p2ForB]);
+    t.deepEqual(log.shift(), [p2ForB, 'urgh', 'urghargs', [], p3ForB]);
+    t.deepEqual(log, []);
+
+    t.deepEqual(kernel.dump().promises, [
+      {
+        id: p1ForKernel,
+        state: 'unresolved',
+        decider: 'vatB',
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: p2ForKernel,
+        state: 'unresolved',
+        decider: 'vatB',
+        subscribers: [],
+        queue: [],
+      },
+      {
+        id: p3ForKernel,
+        state: 'unresolved',
+        decider: 'vatB',
+        subscribers: [],
+        queue: [],
+      },
+    ]);
+
+    t.end();
+  });
+}
+
+if (typeof require !== 'undefined' && typeof module !== 'undefined') {
+  runTests();
+}

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -10,293 +10,302 @@ import makePromise from '../src/makePromise';
 
 import { buildVatController } from '../src/index';
 
-async function prep() {
-  const config = {
-    vats: new Map(),
-    bootstrapIndexJS: undefined,
-  };
-  const controller = await buildVatController(config, false);
-  await controller.run();
-}
-
-maybeExtendPromise(Promise);
-
-test('serialize static data', t => {
-  const m = makeMarshal();
-  const ser = val => m.serialize(val);
-  t.throws(() => ser([1, 2]), /cannot pass non-frozen objects like .*/);
-  t.deepEqual(ser(harden([1, 2])), { argsString: '[1,2]', slots: [] });
-  t.deepEqual(ser(harden({ foo: 1 })), { argsString: '{"foo":1}', slots: [] });
-  t.deepEqual(ser(true), { argsString: 'true', slots: [] });
-  t.deepEqual(ser(1), { argsString: '1', slots: [] });
-  t.deepEqual(ser('abc'), { argsString: '"abc"', slots: [] });
-  t.deepEqual(ser(undefined), {
-    argsString: '{"@qclass":"undefined"}',
-    slots: [],
-  });
-  t.deepEqual(ser(-0), { argsString: '{"@qclass":"-0"}', slots: [] });
-  t.deepEqual(ser(NaN), { argsString: '{"@qclass":"NaN"}', slots: [] });
-  t.deepEqual(ser(Infinity), {
-    argsString: '{"@qclass":"Infinity"}',
-    slots: [],
-  });
-  t.deepEqual(ser(-Infinity), {
-    argsString: '{"@qclass":"-Infinity"}',
-    slots: [],
-  });
-  t.deepEqual(ser(Symbol.for('sym1')), {
-    argsString: '{"@qclass":"symbol","key":"sym1"}',
-    slots: [],
-  });
-  let bn;
-  try {
-    bn = BigInt(4);
-  } catch (e) {
-    if (!(e instanceof ReferenceError)) {
-      throw e;
-    }
+export default function runTests() {
+  async function prep() {
+    const config = {
+      vats: new Map(),
+      bootstrapIndexJS: undefined,
+    };
+    const controller = await buildVatController(config, false);
+    await controller.run();
   }
-  if (bn) {
-    t.deepEqual(ser(bn), {
-      argsString: '{"@qclass":"bigint","digits":"4"}',
+
+  maybeExtendPromise(Promise);
+
+  test('serialize static data', t => {
+    const m = makeMarshal();
+    const ser = val => m.serialize(val);
+    t.throws(() => ser([1, 2]), /cannot pass non-frozen objects like .*/);
+    t.deepEqual(ser(harden([1, 2])), { argsString: '[1,2]', slots: [] });
+    t.deepEqual(ser(harden({ foo: 1 })), {
+      argsString: '{"foo":1}',
       slots: [],
     });
-  }
-
-  let em;
-  try {
-    throw new ReferenceError('msg');
-  } catch (e) {
-    em = harden(e);
-  }
-  t.deepEqual(ser(em), {
-    argsString: '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
-    slots: [],
-  });
-
-  t.end();
-});
-
-test('unserialize static data', t => {
-  const m = makeMarshal();
-  const uns = val => m.unserialize(val, []);
-  t.equal(uns('1'), 1);
-  t.equal(uns('"abc"'), 'abc');
-  t.equal(uns('false'), false);
-
-  // JS primitives that aren't natively representable by JSON
-  t.deepEqual(uns('{"@qclass":"undefined"}'), undefined);
-  t.ok(Object.is(uns('{"@qclass":"-0"}'), -0));
-  t.notOk(Object.is(uns('{"@qclass":"-0"}'), 0));
-  t.ok(Object.is(uns('{"@qclass":"NaN"}'), NaN));
-  t.deepEqual(uns('{"@qclass":"Infinity"}'), Infinity);
-  t.deepEqual(uns('{"@qclass":"-Infinity"}'), -Infinity);
-  t.deepEqual(uns('{"@qclass":"symbol", "key":"sym1"}'), Symbol.for('sym1'));
-
-  // Normal json reviver cannot make properties with undefined values
-  t.deepEqual(uns('[{"@qclass":"undefined"}]'), [undefined]);
-  t.deepEqual(uns('{"foo": {"@qclass":"undefined"}}'), { foo: undefined });
-  let bn;
-  try {
-    bn = BigInt(4);
-  } catch (e) {
-    if (!(e instanceof ReferenceError)) {
-      throw e;
+    t.deepEqual(ser(true), { argsString: 'true', slots: [] });
+    t.deepEqual(ser(1), { argsString: '1', slots: [] });
+    t.deepEqual(ser('abc'), { argsString: '"abc"', slots: [] });
+    t.deepEqual(ser(undefined), {
+      argsString: '{"@qclass":"undefined"}',
+      slots: [],
+    });
+    t.deepEqual(ser(-0), { argsString: '{"@qclass":"-0"}', slots: [] });
+    t.deepEqual(ser(NaN), { argsString: '{"@qclass":"NaN"}', slots: [] });
+    t.deepEqual(ser(Infinity), {
+      argsString: '{"@qclass":"Infinity"}',
+      slots: [],
+    });
+    t.deepEqual(ser(-Infinity), {
+      argsString: '{"@qclass":"-Infinity"}',
+      slots: [],
+    });
+    t.deepEqual(ser(Symbol.for('sym1')), {
+      argsString: '{"@qclass":"symbol","key":"sym1"}',
+      slots: [],
+    });
+    let bn;
+    try {
+      bn = BigInt(4);
+    } catch (e) {
+      if (!(e instanceof ReferenceError)) {
+        throw e;
+      }
     }
-  }
-  if (bn) {
-    t.deepEqual(uns('{"@qclass":"bigint","digits":"1234"}'), BigInt(1234));
-  }
+    if (bn) {
+      t.deepEqual(ser(bn), {
+        argsString: '{"@qclass":"bigint","digits":"4"}',
+        slots: [],
+      });
+    }
 
-  const em1 = uns(
-    '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
-  );
-  t.ok(em1 instanceof ReferenceError);
-  t.equal(em1.message, 'msg');
-  t.ok(Object.isFrozen(em1));
+    let em;
+    try {
+      throw new ReferenceError('msg');
+    } catch (e) {
+      em = harden(e);
+    }
+    t.deepEqual(ser(em), {
+      argsString: '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
+      slots: [],
+    });
 
-  const em2 = uns('{"@qclass":"error","name":"TypeError","message":"msg2"}');
-  t.ok(em2 instanceof TypeError);
-  t.equal(em2.message, 'msg2');
-
-  const em3 = uns('{"@qclass":"error","name":"Unknown","message":"msg3"}');
-  t.ok(em3 instanceof Error);
-  t.equal(em3.message, 'msg3');
-
-  t.deepEqual(uns('[1,2]'), [1, 2]);
-  t.deepEqual(uns('{"a":1,"b":2}'), { a: 1, b: 2 });
-  t.deepEqual(uns('{"a":1,"b":{"c": 3}}'), { a: 1, b: { c: 3 } });
-
-  // should be frozen
-  const arr = uns('[1,2]');
-  t.ok(Object.isFrozen(arr));
-  const a = uns('{"b":{"c":{"d": []}}}');
-  t.ok(Object.isFrozen(a));
-  t.ok(Object.isFrozen(a.b));
-  t.ok(Object.isFrozen(a.b.c));
-  t.ok(Object.isFrozen(a.b.c.d));
-
-  t.end();
-});
-
-test('serialize ibid cycle', t => {
-  const m = makeMarshal();
-  const ser = val => m.serialize(val);
-  const cycle = ['a', 'x', 'c'];
-  cycle[1] = cycle;
-  harden(cycle);
-
-  t.deepEqual(ser(cycle), {
-    argsString: '["a",{"@qclass":"ibid","index":0},"c"]',
-    slots: [],
-  });
-  t.end();
-});
-
-test('forbid ibid cycle', t => {
-  const m = makeMarshal();
-  const uns = val => m.unserialize(val, []);
-  t.throws(
-    () => uns('["a",{"@qclass":"ibid","index":0},"c"]'),
-    /Ibid cycle at 0/,
-  );
-  t.end();
-});
-
-test('unserialize ibid cycle', t => {
-  const m = makeMarshal();
-  const uns = val => m.unserialize(val, [], 'warnOfCycles');
-  const cycle = uns('["a",{"@qclass":"ibid","index":0},"c"]');
-  t.ok(Object.is(cycle[1], cycle));
-  t.end();
-});
-
-test('serialize exports', t => {
-  const { m } = makeMarshaller();
-  const ser = val => m.serialize(val);
-  const o1 = harden({});
-  const o2 = harden({
-    meth1() {
-      return 4;
-    },
-  });
-  t.deepEqual(ser(o1), {
-    argsString: '{"@qclass":"slot","index":0}',
-    slots: ['o+1'],
-  });
-  // m now remembers that o1 is exported as 1
-  t.deepEqual(ser(harden([o1, o1])), {
-    argsString: '[{"@qclass":"slot","index":0},{"@qclass":"ibid","index":1}]',
-    slots: ['o+1'],
-  });
-  t.deepEqual(ser(harden([o2, o1])), {
-    argsString: '[{"@qclass":"slot","index":0},{"@qclass":"slot","index":1}]',
-    slots: ['o+2', 'o+1'],
+    t.end();
   });
 
-  t.end();
-});
+  test('unserialize static data', t => {
+    const m = makeMarshal();
+    const uns = val => m.unserialize(val, []);
+    t.equal(uns('1'), 1);
+    t.equal(uns('"abc"'), 'abc');
+    t.equal(uns('false'), false);
 
-test('deserialize imports', async t => {
-  await prep();
-  const { m } = makeMarshaller();
-  const a = m.unserialize('{"@qclass":"slot","index":0}', ['o-1']);
-  // a should be a proxy/presence. For now these are obvious.
-  t.equal(a.toString(), '[Presence o-1]');
-  t.ok(Object.isFrozen(a));
+    // JS primitives that aren't natively representable by JSON
+    t.deepEqual(uns('{"@qclass":"undefined"}'), undefined);
+    t.ok(Object.is(uns('{"@qclass":"-0"}'), -0));
+    t.notOk(Object.is(uns('{"@qclass":"-0"}'), 0));
+    t.ok(Object.is(uns('{"@qclass":"NaN"}'), NaN));
+    t.deepEqual(uns('{"@qclass":"Infinity"}'), Infinity);
+    t.deepEqual(uns('{"@qclass":"-Infinity"}'), -Infinity);
+    t.deepEqual(uns('{"@qclass":"symbol", "key":"sym1"}'), Symbol.for('sym1'));
 
-  // m now remembers the proxy
-  const b = m.unserialize('{"@qclass":"slot","index":0}', ['o-1']);
-  t.is(a, b);
+    // Normal json reviver cannot make properties with undefined values
+    t.deepEqual(uns('[{"@qclass":"undefined"}]'), [undefined]);
+    t.deepEqual(uns('{"foo": {"@qclass":"undefined"}}'), { foo: undefined });
+    let bn;
+    try {
+      bn = BigInt(4);
+    } catch (e) {
+      if (!(e instanceof ReferenceError)) {
+        throw e;
+      }
+    }
+    if (bn) {
+      t.deepEqual(uns('{"@qclass":"bigint","digits":"1234"}'), BigInt(1234));
+    }
 
-  // the slotid is what matters, not the index
-  const c = m.unserialize('{"@qclass":"slot","index":2}', ['x', 'x', 'o-1']);
-  t.is(a, c);
+    const em1 = uns(
+      '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
+    );
+    t.ok(em1 instanceof ReferenceError);
+    t.equal(em1.message, 'msg');
+    t.ok(Object.isFrozen(em1));
 
-  t.end();
-});
+    const em2 = uns('{"@qclass":"error","name":"TypeError","message":"msg2"}');
+    t.ok(em2 instanceof TypeError);
+    t.equal(em2.message, 'msg2');
 
-test('deserialize exports', t => {
-  const { m } = makeMarshaller();
-  const o1 = harden({});
-  m.serialize(o1); // allocates slot=1
-  const a = m.unserialize('{"@qclass":"slot","index":0}', ['o+1']);
-  t.is(a, o1);
+    const em3 = uns('{"@qclass":"error","name":"Unknown","message":"msg3"}');
+    t.ok(em3 instanceof Error);
+    t.equal(em3.message, 'msg3');
 
-  t.end();
-});
+    t.deepEqual(uns('[1,2]'), [1, 2]);
+    t.deepEqual(uns('{"a":1,"b":2}'), { a: 1, b: 2 });
+    t.deepEqual(uns('{"a":1,"b":{"c": 3}}'), { a: 1, b: { c: 3 } });
 
-test('serialize imports', async t => {
-  await prep();
-  const { m } = makeMarshaller();
-  const a = m.unserialize('{"@qclass":"slot","index":0}', ['o-1']);
-  t.deepEqual(m.serialize(a), {
-    argsString: '{"@qclass":"slot","index":0}',
-    slots: ['o-1'],
+    // should be frozen
+    const arr = uns('[1,2]');
+    t.ok(Object.isFrozen(arr));
+    const a = uns('{"b":{"c":{"d": []}}}');
+    t.ok(Object.isFrozen(a));
+    t.ok(Object.isFrozen(a.b));
+    t.ok(Object.isFrozen(a.b.c));
+    t.ok(Object.isFrozen(a.b.c.d));
+
+    t.end();
   });
 
-  t.end();
-});
+  test('serialize ibid cycle', t => {
+    const m = makeMarshal();
+    const ser = val => m.serialize(val);
+    const cycle = ['a', 'x', 'c'];
+    cycle[1] = cycle;
+    harden(cycle);
 
-test('serialize promise', async t => {
-  const log = [];
-  const syscall = {
-    fulfillToData(result, data, slots) {
-      log.push({ result, data, slots });
-    },
-  };
-
-  const { m } = makeMarshaller(syscall);
-  const { p, res } = makePromise();
-  t.deepEqual(m.serialize(p), {
-    argsString: '{"@qclass":"slot","index":0}',
-    slots: ['p+5'],
-  });
-  // serializer should remember the promise
-  t.deepEqual(m.serialize(harden(['other stuff', p])), {
-    argsString: '["other stuff",{"@qclass":"slot","index":0}]',
-    slots: ['p+5'],
+    t.deepEqual(ser(cycle), {
+      argsString: '["a",{"@qclass":"ibid","index":0},"c"]',
+      slots: [],
+    });
+    t.end();
   });
 
-  // inbound should recognize it and return the promise
-  t.deepEqual(m.unserialize('{"@qclass":"slot","index":0}', ['p+5']), p);
+  test('forbid ibid cycle', t => {
+    const m = makeMarshal();
+    const uns = val => m.unserialize(val, []);
+    t.throws(
+      () => uns('["a",{"@qclass":"ibid","index":0},"c"]'),
+      /Ibid cycle at 0/,
+    );
+    t.end();
+  });
 
-  res(5);
-  t.deepEqual(log, []);
+  test('unserialize ibid cycle', t => {
+    const m = makeMarshal();
+    const uns = val => m.unserialize(val, [], 'warnOfCycles');
+    const cycle = uns('["a",{"@qclass":"ibid","index":0},"c"]');
+    t.ok(Object.is(cycle[1], cycle));
+    t.end();
+  });
 
-  const { p: pauseP, res: pauseRes } = makePromise();
-  setImmediate(() => pauseRes());
-  await pauseP;
-  t.deepEqual(log, [{ result: 'p+5', data: '5', slots: [] }]);
+  test('serialize exports', t => {
+    const { m } = makeMarshaller();
+    const ser = val => m.serialize(val);
+    const o1 = harden({});
+    const o2 = harden({
+      meth1() {
+        return 4;
+      },
+    });
+    t.deepEqual(ser(o1), {
+      argsString: '{"@qclass":"slot","index":0}',
+      slots: ['o+1'],
+    });
+    // m now remembers that o1 is exported as 1
+    t.deepEqual(ser(harden([o1, o1])), {
+      argsString: '[{"@qclass":"slot","index":0},{"@qclass":"ibid","index":1}]',
+      slots: ['o+1'],
+    });
+    t.deepEqual(ser(harden([o2, o1])), {
+      argsString: '[{"@qclass":"slot","index":0},{"@qclass":"slot","index":1}]',
+      slots: ['o+2', 'o+1'],
+    });
 
-  t.end();
-});
+    t.end();
+  });
 
-test('unserialize promise', async t => {
-  await prep();
-  const log = [];
-  const syscall = {
-    subscribe(promiseID) {
-      log.push(`subscribe-${promiseID}`);
-    },
-  };
+  test('deserialize imports', async t => {
+    await prep();
+    const { m } = makeMarshaller();
+    const a = m.unserialize('{"@qclass":"slot","index":0}', ['o-1']);
+    // a should be a proxy/presence. For now these are obvious.
+    t.equal(a.toString(), '[Presence o-1]');
+    t.ok(Object.isFrozen(a));
 
-  const { m } = makeMarshaller(syscall);
-  const p = m.unserialize('{"@qclass":"slot","index":0}', ['p-1']);
-  t.deepEqual(log, ['subscribe-p-1']);
-  t.ok(p instanceof Promise);
+    // m now remembers the proxy
+    const b = m.unserialize('{"@qclass":"slot","index":0}', ['o-1']);
+    t.is(a, b);
 
-  t.end();
-});
+    // the slotid is what matters, not the index
+    const c = m.unserialize('{"@qclass":"slot","index":2}', ['x', 'x', 'o-1']);
+    t.is(a, c);
 
-test('null cannot be pass-by-presence', t => {
-  t.throws(() => mustPassByPresence(null), /null cannot be pass-by-presence/);
-  t.end();
-});
+    t.end();
+  });
 
-test('mal-formed @qclass', t => {
-  const m = makeMarshal();
-  const uns = val => m.unserialize(val, []);
-  t.throws(() => uns('{"@qclass": 0}'), /invalid qclass/);
-  t.end();
-});
+  test('deserialize exports', t => {
+    const { m } = makeMarshaller();
+    const o1 = harden({});
+    m.serialize(o1); // allocates slot=1
+    const a = m.unserialize('{"@qclass":"slot","index":0}', ['o+1']);
+    t.is(a, o1);
+
+    t.end();
+  });
+
+  test('serialize imports', async t => {
+    await prep();
+    const { m } = makeMarshaller();
+    const a = m.unserialize('{"@qclass":"slot","index":0}', ['o-1']);
+    t.deepEqual(m.serialize(a), {
+      argsString: '{"@qclass":"slot","index":0}',
+      slots: ['o-1'],
+    });
+
+    t.end();
+  });
+
+  test('serialize promise', async t => {
+    const log = [];
+    const syscall = {
+      fulfillToData(result, data, slots) {
+        log.push({ result, data, slots });
+      },
+    };
+
+    const { m } = makeMarshaller(syscall);
+    const { p, res } = makePromise();
+    t.deepEqual(m.serialize(p), {
+      argsString: '{"@qclass":"slot","index":0}',
+      slots: ['p+5'],
+    });
+    // serializer should remember the promise
+    t.deepEqual(m.serialize(harden(['other stuff', p])), {
+      argsString: '["other stuff",{"@qclass":"slot","index":0}]',
+      slots: ['p+5'],
+    });
+
+    // inbound should recognize it and return the promise
+    t.deepEqual(m.unserialize('{"@qclass":"slot","index":0}', ['p+5']), p);
+
+    res(5);
+    t.deepEqual(log, []);
+
+    const { p: pauseP, res: pauseRes } = makePromise();
+    setImmediate(() => pauseRes());
+    await pauseP;
+    t.deepEqual(log, [{ result: 'p+5', data: '5', slots: [] }]);
+
+    t.end();
+  });
+
+  test('unserialize promise', async t => {
+    await prep();
+    const log = [];
+    const syscall = {
+      subscribe(promiseID) {
+        log.push(`subscribe-${promiseID}`);
+      },
+    };
+
+    const { m } = makeMarshaller(syscall);
+    const p = m.unserialize('{"@qclass":"slot","index":0}', ['p-1']);
+    t.deepEqual(log, ['subscribe-p-1']);
+    t.ok(p instanceof Promise);
+
+    t.end();
+  });
+
+  test('null cannot be pass-by-presence', t => {
+    t.throws(() => mustPassByPresence(null), /null cannot be pass-by-presence/);
+    t.end();
+  });
+
+  test('mal-formed @qclass', t => {
+    const m = makeMarshal();
+    const uns = val => m.unserialize(val, []);
+    t.throws(() => uns('{"@qclass": 0}'), /invalid qclass/);
+    t.end();
+  });
+}
+
+if (typeof require !== 'undefined' && typeof module !== 'undefined') {
+  runTests();
+}


### PR DESCRIPTION
This is effectively a rebase of #133 on top of the (extensive) changes
wrought by #88. But it was achieved by just inserting the same function
wrapper around the whole file and then re-running 'npm run eslint-fix' to
adjust the indentation.

Run 'git diff -w' to see that there were no unexpected semantic changes.

closes #133
refs #130