### PR TITLE
switch to new 'CapData' and 'Message' types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
       "integrity": "sha512-0k/wGkIVQO3IY7p/H/5OS3BIXsRK9Qb7nHnqyvj6hzvSyumwgPp8e4rz5QaVWSen43TGJl+zQn4mW9ZZShT1aw=="
     },
     "@agoric/marshal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@agoric/marshal/-/marshal-0.0.1.tgz",
-      "integrity": "sha512-9gzWDG0lYKug9lamqom6sabtUj4Nb1r7m1UJ7bscoYbufb+XJKS+WbLTmAfQjsSZhV1aofTmEpNzMxglzLwoPw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@agoric/marshal/-/marshal-0.1.0.tgz",
+      "integrity": "sha512-T3QbXI9/lm+fORJ5uK7cRbPZGogfr741pF0iuS6IdrMG+jJE76CG/1enu4HjKMCZ+0GmPHTz6DbIDR/D4smqlA==",
       "requires": {
         "@agoric/harden": "0.0.4",
         "@agoric/nat": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@agoric/default-evaluate-options": "^0.1.3",
     "@agoric/evaluate": "^1.3.2",
     "@agoric/harden": "^0.0.4",
-    "@agoric/marshal": "0.0.1",
+    "@agoric/marshal": "^0.1.0",
     "@agoric/nat": "^2.0.0",
     "rollup": "^1.19.3",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/src/capdata.js
+++ b/src/capdata.js
@@ -1,0 +1,12 @@
+import { insist } from './insist';
+
+export function insistCapData(capdata) {
+  insist(
+    capdata.body === `${capdata.body}`,
+    `capdata has non-string .body ${capdata.body}`,
+  );
+  insist(
+    capdata.slots instanceof Array,
+    `capdata has non-Array slots ${capdata.slots}`,
+  );
+}

--- a/src/controller.js
+++ b/src/controller.js
@@ -12,6 +12,7 @@ import makeDefaultEvaluateOptions from '@agoric/default-evaluate-options';
 import kernelSourceFunc from './bundles/kernel';
 import buildKernelNonSES from './kernel/index';
 import bundleSource from './build-source-bundle';
+import { insistCapData } from './capdata';
 
 const evaluateOptions = makeDefaultEvaluateOptions();
 
@@ -211,9 +212,10 @@ export async function buildVatController(config, withSES = true, argv = []) {
       await kernel.step();
     },
 
-    queueToExport(vatID, facetID, method, argsString) {
+    queueToExport(vatID, facetID, method, args) {
+      insistCapData(args);
       kernel.addExport(vatID, facetID);
-      kernel.queueToExport(vatID, facetID, method, argsString, []);
+      kernel.queueToExport(vatID, facetID, method, args);
     },
 
     callBootstrap(vatID, bootstrapArgv) {

--- a/src/kernel/state/kernelKeeper.js
+++ b/src/kernel/state/kernelKeeper.js
@@ -2,6 +2,7 @@ import harden from '@agoric/harden';
 import makeVatKeeper from './vatKeeper';
 import makeDeviceKeeper from './deviceKeeper';
 import { insistKernelType, makeKernelSlot } from '../parseKernelSlots';
+import { insistCapData } from '../../capdata';
 
 // This holds all the kernel state, including that of each Vat and Device, in
 // a single JSON-serializable object. At any moment (well, really only
@@ -96,25 +97,25 @@ function makeKernelKeeper(initialState) {
     insistKernelType('promise', kernelSlot);
     state.kernelPromises[kernelSlot] = harden({
       state: 'fulfilledToPresence',
-      fulfillSlot: targetSlot,
+      slot: targetSlot,
     });
   }
 
-  function fulfillKernelPromiseToData(kernelSlot, data, slots) {
+  function fulfillKernelPromiseToData(kernelSlot, capdata) {
     insistKernelType('promise', kernelSlot);
+    insistCapData(capdata);
     state.kernelPromises[kernelSlot] = harden({
       state: 'fulfilledToData',
-      fulfillData: data,
-      fulfillSlots: slots,
+      data: capdata,
     });
   }
 
-  function rejectKernelPromise(kernelSlot, val, valSlots) {
+  function rejectKernelPromise(kernelSlot, capdata) {
     insistKernelType('promise', kernelSlot);
+    insistCapData(capdata);
     state.kernelPromises[kernelSlot] = harden({
       state: 'rejected',
-      rejectData: val,
-      rejectSlots: valSlots,
+      data: capdata,
     });
   }
 

--- a/src/message.js
+++ b/src/message.js
@@ -1,0 +1,16 @@
+import { insist } from './insist';
+import { insistCapData } from './capdata';
+
+export function insistMessage(message) {
+  insist(
+    message.method === `${message.method}`,
+    `message has non-string .method ${message.method}`,
+  );
+  insistCapData(message.args);
+  if (message.result) {
+    insist(
+      message.result === `${message.result}`,
+      `message has non-string non-null .result ${message.result}`,
+    );
+  }
+}

--- a/src/vats/comms/controller.js
+++ b/src/vats/comms/controller.js
@@ -1,9 +1,13 @@
 import Nat from '@agoric/nat';
+import harden from '@agoric/harden';
 import { addRemote } from './remote';
 import { addEgress, addIngress } from './clist';
 import { insist } from '../../insist';
 
-const UNDEFINED = JSON.stringify({ '@qclass': 'undefined' });
+const UNDEFINED = harden({
+  body: JSON.stringify({ '@qclass': 'undefined' }),
+  slots: [],
+});
 
 // deliverToController() is used for local vats which want to talk to us as a
 // vat, rather than as a conduit to talk to remote vats. The bootstrap
@@ -17,21 +21,29 @@ const UNDEFINED = JSON.stringify({ '@qclass': 'undefined' });
 export function deliverToController(
   state,
   method,
-  data,
-  slots,
+  controllerArgs,
   result,
   syscall,
 ) {
-  function doAddRemote(args) {
+  // We use a degenerate form of deserialization, just enough to handle the
+  // handful of methods implemented by the commsController. 'args.body' can
+  // normally have arbitrary {'@qclass': whatever} objects, but we only
+  // handle {'@qclass':'slot', index} objects, which point into the
+  // 'args.slots' array.
+
+  function doAddRemote() {
     // comms!addRemote(name, tx, setRx)
     //  we then do setRx!setReceiver(rx)
+    const args = JSON.parse(controllerArgs.body);
+    const { slots } = controllerArgs;
+
     const name = args[0];
     insist(name === `${name}`, `bad addRemote name ${name}`);
     if (args[1]['@qclass'] !== 'slot' || args[1].index !== 0) {
-      throw new Error(`unexpected args for addRemote(): ${data}`);
+      throw new Error(`unexpected args for addRemote(): ${controllerArgs}`);
     }
     if (args[2]['@qclass'] !== 'slot' || args[2].index !== 1) {
-      throw new Error(`unexpected args for addRemote(): ${data}`);
+      throw new Error(`unexpected args for addRemote(): ${controllerArgs}`);
     }
     const transmitterID = slots[args[1].index];
     const setReceiverID = slots[args[2].index];
@@ -39,30 +51,38 @@ export function deliverToController(
     const { receiverID } = addRemote(state, name, transmitterID);
 
     const rxArg = { '@qclass': 'slot', index: 0 };
-    const setReceiverBody = JSON.stringify({ args: [rxArg] });
-    syscall.send(setReceiverID, 'setReceiver', setReceiverBody, [receiverID]);
+    const setReceiverArgs = harden({
+      body: JSON.stringify([rxArg]),
+      slots: [receiverID],
+    });
+    syscall.send(setReceiverID, 'setReceiver', setReceiverArgs);
     // todo: consider, this leaves one message (setReceiver) on the queue,
     // rather than giving the caller of comms!addRemote() something to
     // synchronize upon. I don't think it hurts, but might affect debugging.
-    syscall.fulfillToData(result, UNDEFINED, []);
+    syscall.fulfillToData(result, UNDEFINED);
   }
 
-  function doAddEgress(args) {
+  function doAddEgress() {
     // comms!addEgress(name, index, obj)
+    const args = JSON.parse(controllerArgs.body);
+    const { slots } = controllerArgs;
+
     const remoteName = args[0];
     insist(state.names.has(remoteName), `unknown remote name ${remoteName}`);
     const remoteID = state.names.get(remoteName);
     const remoteRefID = Nat(args[1]);
     if (args[2]['@qclass'] !== 'slot' || args[2].index !== 0) {
-      throw new Error(`unexpected args for addEgress(): ${data}`);
+      throw new Error(`unexpected args for addEgress(): ${controllerArgs}`);
     }
     const localRef = slots[args[2].index];
     addEgress(state, remoteID, remoteRefID, localRef);
-    syscall.fulfillToData(result, UNDEFINED, []);
+    syscall.fulfillToData(result, UNDEFINED);
   }
 
-  function doAddIngress(args) {
+  function doAddIngress() {
     // obj = comms!addIngress(name, index)
+    const args = JSON.parse(controllerArgs.body);
+
     const remoteName = args[0];
     insist(state.names.has(remoteName), `unknown remote name ${remoteName}`);
     const remoteID = state.names.get(remoteName);
@@ -71,20 +91,13 @@ export function deliverToController(
     syscall.fulfillToPresence(result, localRef);
   }
 
-  // This is a degenerate form of deserialization, just enough to handle the
-  // handful of methods implemented by the commsController. 'argsbytes' can
-  // normally have arbitrary {'@qclass': whatever} objects, but we only
-  // handle {'@qclass':'slot', index} objects, which point into the 'slots'
-  // array.
-  const { args } = JSON.parse(data);
-
   switch (method) {
     case 'addRemote':
-      return doAddRemote(args);
+      return doAddRemote();
     case 'addEgress':
-      return doAddEgress(args);
+      return doAddEgress();
     case 'addIngress':
-      return doAddIngress(args);
+      return doAddIngress();
     default:
       throw new Error(`method ${method} is not available`);
   }

--- a/src/vats/comms/state.js
+++ b/src/vats/comms/state.js
@@ -1,4 +1,5 @@
 import { insist } from '../../insist';
+import { insistCapData } from '../../capdata';
 import { makeVatSlot } from '../../parseVatSlots';
 
 export function makeState() {
@@ -16,8 +17,8 @@ export function makeState() {
     promiseTable: new Map(), // p+NN/p-NN -> { state, owner, decider, subscriber }
     // and maybe resolution, one of:
     // * {type: 'object', slot}
-    // * {type: 'data', body, slots}
-    // * {type: 'reject', body, slots}
+    // * {type: 'data', data}
+    // * {type: 'reject', data}
     nextPromiseIndex: 20,
   };
 
@@ -132,6 +133,16 @@ export function markPromiseAsResolved(state, promiseID, resolution) {
     p.state === 'unresolved',
     `${promiseID} is already resolved (${p.state})`,
   );
+  if (resolution.type === 'object') {
+    insist(resolution.slot, `resolution(object) requires .slot`);
+  } else if (resolution.type === 'data') {
+    insistCapData(resolution.data);
+  } else if (resolution.type === 'reject') {
+    insistCapData(resolution.data);
+  } else {
+    throw new Error(`unknown resolution type ${resolution.type}`);
+  }
+  p.state = 'resolved';
   p.resolution = resolution;
   p.decider = undefined;
   p.subscriber = undefined;

--- a/test/files-devices/bootstrap-0.js
+++ b/test/files-devices/bootstrap-0.js
@@ -3,9 +3,9 @@ const harden = require('@agoric/harden');
 export default function setup(syscall, state, helpers, _devices) {
   const { log } = helpers;
   const dispatch = harden({
-    deliver(facetid, method, argsbytes, caps, _result) {
-      log(argsbytes);
-      log(JSON.stringify(caps));
+    deliver(facetid, method, args, _result) {
+      log(args.body);
+      log(JSON.stringify(args.slots));
     },
   });
   return dispatch;

--- a/test/files-devices/bootstrap-1.js
+++ b/test/files-devices/bootstrap-1.js
@@ -4,18 +4,19 @@ export default function setup(syscall, state, helpers, _devices) {
   const { log } = helpers;
   let deviceRef;
   const dispatch = harden({
-    deliver(facetid, method, argsbytes, caps, _result) {
+    deliver(facetid, method, args, _result) {
       if (method === 'bootstrap') {
-        const { args } = JSON.parse(argsbytes);
-        const deviceIndex = args[2].d1.index;
-        deviceRef = caps[deviceIndex];
+        const argb = JSON.parse(args.body);
+        const deviceIndex = argb[2].d1.index;
+        deviceRef = args.slots[deviceIndex];
         if (deviceRef !== 'd-70') {
           throw new Error(`bad deviceRef ${deviceRef}`);
         }
       } else if (method === 'step1') {
         console.log('in step1');
         log(`callNow`);
-        const ret = syscall.callNow(deviceRef, 'set', '{}', []);
+        const setArgs = harden({ body: JSON.stringify([]), slots: [] });
+        const ret = syscall.callNow(deviceRef, 'set', setArgs);
         log(JSON.stringify(ret));
       }
     },

--- a/test/files-devices/device-0.js
+++ b/test/files-devices/device-0.js
@@ -2,10 +2,8 @@ const harden = require('@agoric/harden');
 
 export default function setup(_syscall, _state, _helpers, _endowments) {
   const dispatch = harden({
-    invoke(_target, _method, _argsData, _argsSlots) {
-      const args = '';
-      const slots = [];
-      return { args, slots };
+    invoke(_target, _method, _args) {
+      return harden({ body: '', slots: [] });
     },
     getState() {
       return '';

--- a/test/files-devices/device-1.js
+++ b/test/files-devices/device-1.js
@@ -3,12 +3,10 @@ const harden = require('@agoric/harden');
 export default function setup(syscall, state, helpers, endowments) {
   const { log } = helpers;
   const dispatch = harden({
-    invoke(targetID, method, _argsData, _argsSlots) {
+    invoke(targetID, method, _args) {
       log(`invoke ${targetID} ${method}`);
       endowments.shared.push('pushed');
-      const data = '{}';
-      const slots = [];
-      return { data, slots };
+      return harden({ body: JSON.stringify([]), slots: [] });
     },
     getState() {
       return '';

--- a/test/test-comms.js
+++ b/test/test-comms.js
@@ -28,8 +28,8 @@ test('mapOutbound', t => {
 function mockSyscall() {
   const sends = [];
   const syscall = harden({
-    send(targetSlot, method, argsString, vatSlots) {
-      sends.push([targetSlot, method, argsString, vatSlots]);
+    send(targetSlot, method, args) {
+      sends.push([targetSlot, method, args]);
       return 'r-1';
     },
     subscribe(_targetSlot) {},
@@ -37,8 +37,12 @@ function mockSyscall() {
   return { syscall, sends };
 }
 
+function capdata(body, slots = []) {
+  return harden({ body, slots });
+}
+
 function encodeArgs(body) {
-  return JSON.stringify({ args: [body] });
+  return capdata(JSON.stringify([body]), []);
 }
 
 test('transmit', t => {
@@ -55,41 +59,37 @@ test('transmit', t => {
 
   // now tell the comms vat to send a message to a remote machine, the
   // equivalent of bob!foo()
-  d.deliver(bob, 'foo', 'argsbytes', [], null);
+  d.deliver(bob, 'foo', capdata('argsbytes', []), null);
   t.deepEquals(sends.shift(), [
     transmitterID,
     'transmit',
     encodeArgs('deliver:ro+23:foo:;argsbytes'),
-    [],
   ]);
 
   // bob!bar(alice, bob)
-  d.deliver(bob, 'bar', 'argsbytes', [alice, bob], null);
+  d.deliver(bob, 'bar', capdata('argsbytes', [alice, bob]), null);
   t.deepEquals(sends.shift(), [
     transmitterID,
     'transmit',
     encodeArgs('deliver:ro+23:bar::ro-20:ro+23;argsbytes'),
-    [],
   ]);
   // the outbound ro-20 should match an inbound ro+20, both represent 'alice'
   t.equal(getInbound(state, remoteID, 'ro+20'), alice);
   // do it again, should use same values
-  d.deliver(bob, 'bar', 'argsbytes', [alice, bob], null);
+  d.deliver(bob, 'bar', capdata('argsbytes', [alice, bob]), null);
   t.deepEquals(sends.shift(), [
     transmitterID,
     'transmit',
     encodeArgs('deliver:ro+23:bar::ro-20:ro+23;argsbytes'),
-    [],
   ]);
 
   // bob!cat(alice, bob, ayana)
   const ayana = 'o-11';
-  d.deliver(bob, 'cat', 'argsbytes', [alice, bob, ayana], null);
+  d.deliver(bob, 'cat', capdata('argsbytes', [alice, bob, ayana]), null);
   t.deepEquals(sends.shift(), [
     transmitterID,
     'transmit',
     encodeArgs('deliver:ro+23:cat::ro-20:ro+23:ro-21;argsbytes'),
-    [],
   ]);
 
   t.end();
@@ -114,20 +114,22 @@ test('receive', t => {
     receiverID,
     'receive',
     encodeArgs(`deliver:${remoteBob}:foo:;argsbytes`),
-    [],
     null,
   );
-  t.deepEquals(sends.shift(), [bob, 'foo', 'argsbytes', []]);
+  t.deepEquals(sends.shift(), [bob, 'foo', capdata('argsbytes')]);
 
   // bob!bar(alice, bob)
   d.deliver(
     receiverID,
     'receive',
     encodeArgs(`deliver:${remoteBob}:bar::ro-20:${remoteBob};argsbytes`),
-    [],
     null,
   );
-  t.deepEquals(sends.shift(), [bob, 'bar', 'argsbytes', ['o+11', bob]]);
+  t.deepEquals(sends.shift(), [
+    bob,
+    'bar',
+    capdata('argsbytes', ['o+11', bob]),
+  ]);
   // if we were to send o+11, the other side should get ro+20, which is alice
   t.equal(getOutbound(state, remoteID, 'o+11'), 'ro+20');
 
@@ -136,20 +138,26 @@ test('receive', t => {
     receiverID,
     'receive',
     encodeArgs(`deliver:${remoteBob}:bar::ro-20:${remoteBob};argsbytes`),
-    [],
     null,
   );
-  t.deepEquals(sends.shift(), [bob, 'bar', 'argsbytes', ['o+11', bob]]);
+  t.deepEquals(sends.shift(), [
+    bob,
+    'bar',
+    capdata('argsbytes', ['o+11', bob]),
+  ]);
 
   // bob!cat(alice, bob, ayana)
   d.deliver(
     receiverID,
     'receive',
     encodeArgs(`deliver:${remoteBob}:cat::ro-20:${remoteBob}:ro-21;argsbytes`),
-    [],
     null,
   );
-  t.deepEquals(sends.shift(), [bob, 'cat', 'argsbytes', ['o+11', bob, 'o+12']]);
+  t.deepEquals(sends.shift(), [
+    bob,
+    'cat',
+    capdata('argsbytes', ['o+11', bob, 'o+12']),
+  ]);
 
   t.end();
 });

--- a/test/test-devices.js
+++ b/test/test-devices.js
@@ -1,7 +1,16 @@
 import { test } from 'tape-promise/tape';
+import harden from '@agoric/harden';
 import { buildVatController } from '../src/index';
 import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox';
 import buildCommand from '../src/devices/command';
+
+function capdata(body, slots = []) {
+  return harden({ body, slots });
+}
+
+function capargs(args, slots = []) {
+  return capdata(JSON.stringify(args), slots);
+}
 
 async function test0(t, withSES) {
   const config = {
@@ -12,18 +21,16 @@ async function test0(t, withSES) {
   const c = await buildVatController(config, withSES);
   await c.step();
   // console.log(util.inspect(c.dump(), { depth: null }));
-  t.deepEqual(JSON.parse(c.dump().log[0]), {
-    args: [
-      [],
-      {
-        _bootstrap: { '@qclass': 'slot', index: 0 },
-      },
-      {
-        _dummy: 'dummy',
-        d0: { '@qclass': 'slot', index: 1 },
-      },
-    ],
-  });
+  t.deepEqual(JSON.parse(c.dump().log[0]), [
+    [],
+    {
+      _bootstrap: { '@qclass': 'slot', index: 0 },
+    },
+    {
+      _dummy: 'dummy',
+      d0: { '@qclass': 'slot', index: 1 },
+    },
+  ]);
   t.deepEqual(JSON.parse(c.dump().log[1]), ['o+0', 'd-70']);
   t.end();
 }
@@ -53,13 +60,13 @@ async function test1(t, withSES) {
   };
   const c = await buildVatController(config, withSES);
   await c.step();
-  c.queueToExport('_bootstrap', 'o+0', 'step1', '{"args":[]}');
+  c.queueToExport('_bootstrap', 'o+0', 'step1', capargs([]));
   await c.step();
   console.log(c.dump().log);
   t.deepEqual(c.dump().log, [
     'callNow',
     'invoke d+0 set',
-    '{"data":"{}","slots":[]}',
+    JSON.stringify(capargs([])),
   ]);
   t.deepEqual(sharedArray, ['pushed']);
   t.end();

--- a/test/test-message-patterns.js
+++ b/test/test-message-patterns.js
@@ -38,7 +38,7 @@ async function runWithTrace(c) {
         console.log(
           ` send ${q.msg.result} = ${q.target}!${
             q.msg.method
-          }(${q.msg.slots.join(',')} ${q.msg.argsString})`,
+          }(${q.msg.args.slots.join(',')} ${q.msg.args.body})`,
         );
       } else if (q.type === 'notify') {
         console.log(` notify ${q.vatID}: ${q.kpid}`);

--- a/test/vat-controller-1
+++ b/test/vat-controller-1
@@ -1,7 +1,7 @@
 // -*- js -*-
 export default function start(syscall, _state, helpers) {
-  function deliver(facetID, method, argsString, slots) {
-    helpers.log(JSON.stringify({ facetID, method, argsString, slots }));
+  function deliver(facetID, method, args) {
+    helpers.log(JSON.stringify({ facetID, method, args }));
   }
   return { deliver };
 }


### PR DESCRIPTION
Previously, each syscall/dispatch API (and lots of internal interfaces, like the run-queue) used an inconsistent variety of ways to pass the two halves of "data that can include capability references": the string of serialized data, plus the array of slots (like 'o+4' and 'p-4').

This defines a type (to the extent that one can define types in Javascript) named "CapData" to hold "capability-bearing data". Instances of this type contain exactly `{ body, slots }`. All API signatures that used to pass two arguments now pass a single CapData-typed argument.

It also defines a type named "Message", which contains `{ method, args, result }`, where `method` is a string that names the method to be invoked, `args` is a CapData whose top-level member is an array (of positional arguments), and `result` is either a promise reference or `null`/`undefined`.

"Message" is not revealed to Vats, but the various in-kernel run-queues and delivery APIs are now written in terms of Messages rather than distinct method / args / result fields.

This depends upon a new version of `@agoric/marshal` which uses CapData in serialize/unserialize, rather than separate string and slots arguments.

refs #28
