### PR TITLE
change device controller to not expect setup to be default export

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -173,16 +173,16 @@ export async function buildVatController(config, withSES = true, argv = []) {
       );
     }
 
-    let setup;
+    let setupProvider;
     if (withSES) {
       let source = await bundleSource(`${sourceIndex}`);
       source = `(${source})`;
-      setup = s.evaluate(source, { require: r })();
+      setupProvider = s.evaluate(source, { require: r })();
     } else {
       // eslint-disable-next-line global-require,import/no-dynamic-require
-      setup = require(`${sourceIndex}`).default;
+      setupProvider = require(`${sourceIndex}`);
     }
-    kernel.addGenesisDevice(name, setup, endowments);
+    kernel.addGenesisDevice(name, setupProvider.setup, endowments);
   }
 
   // the kernel won't leak our objects into the Vats, we must do

--- a/src/devices/command-src.js
+++ b/src/devices/command-src.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 import Nat from '@agoric/nat';
 
-export default function setup(syscall, state, helpers, endowments) {
+function setup(syscall, state, helpers, endowments) {
   const {
     registerInboundCallback,
     deliverResponse,
@@ -50,3 +50,5 @@ export default function setup(syscall, state, helpers, endowments) {
 
   return helpers.makeDeviceSlots(syscall, state, build, helpers.name);
 }
+
+export { setup };

--- a/src/devices/inbound-src.js
+++ b/src/devices/inbound-src.js
@@ -1,6 +1,6 @@
 import harden from '@agoric/harden';
 
-export default function setup(syscall, state, helpers, endowments) {
+function setup(syscall, state, helpers, endowments) {
   const { bridge } = endowments;
   let { inboundHandler } = state.get() || {};
 
@@ -30,3 +30,5 @@ export default function setup(syscall, state, helpers, endowments) {
     helpers.name,
   );
 }
+
+export { setup };

--- a/src/devices/loopbox-src.js
+++ b/src/devices/loopbox-src.js
@@ -1,6 +1,6 @@
 import harden from '@agoric/harden';
 
-export default function setup(syscall, state, helpers, _endowments) {
+function setup(syscall, state, helpers, _endowments) {
   const inboundHandlers = harden(new Map());
 
   return helpers.makeDeviceSlots(
@@ -36,3 +36,5 @@ export default function setup(syscall, state, helpers, _endowments) {
     helpers.name,
   );
 }
+
+export { setup };

--- a/src/devices/mailbox-src.js
+++ b/src/devices/mailbox-src.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 import Nat from '@agoric/nat';
 
-export default function setup(syscall, state, helpers, endowments) {
+function setup(syscall, state, helpers, endowments) {
   const highestInboundDelivered = harden(new Map());
   const highestInboundAck = harden(new Map());
 
@@ -114,3 +114,5 @@ export default function setup(syscall, state, helpers, endowments) {
 
   return helpers.makeDeviceSlots(syscall, state, build, helpers.name);
 }
+
+export { setup };

--- a/test/files-devices/device-0.js
+++ b/test/files-devices/device-0.js
@@ -1,6 +1,6 @@
 const harden = require('@agoric/harden');
 
-export default function setup(_syscall, _state, _helpers, _endowments) {
+function setup(_syscall, _state, _helpers, _endowments) {
   const dispatch = harden({
     invoke(_target, _method, _args) {
       return harden({ body: '', slots: [] });
@@ -11,3 +11,5 @@ export default function setup(_syscall, _state, _helpers, _endowments) {
   });
   return dispatch;
 }
+
+export { setup };

--- a/test/files-devices/device-1.js
+++ b/test/files-devices/device-1.js
@@ -1,6 +1,6 @@
 const harden = require('@agoric/harden');
 
-export default function setup(syscall, state, helpers, endowments) {
+function setup(syscall, state, helpers, endowments) {
   const { log } = helpers;
   const dispatch = harden({
     invoke(targetID, method, _args) {
@@ -14,3 +14,5 @@ export default function setup(syscall, state, helpers, endowments) {
   });
   return dispatch;
 }
+
+export { setup };

--- a/test/files-devices/device-2.js
+++ b/test/files-devices/device-2.js
@@ -1,6 +1,6 @@
 const harden = require('@agoric/harden');
 
-export default function setup(syscall, state, helpers, _endowments) {
+function setup(syscall, state, helpers, _endowments) {
   const { log } = helpers;
 
   return helpers.makeDeviceSlots(
@@ -54,3 +54,5 @@ export default function setup(syscall, state, helpers, _endowments) {
     helpers.name,
   );
 }
+
+export { setup };

--- a/test/files-devices/device-3.js
+++ b/test/files-devices/device-3.js
@@ -1,6 +1,6 @@
 const harden = require('@agoric/harden');
 
-export default function setup(syscall, state, helpers, _endowments) {
+function setup(syscall, state, helpers, _endowments) {
   const { log } = helpers;
 
   log(state.get());
@@ -22,3 +22,5 @@ export default function setup(syscall, state, helpers, _endowments) {
     helpers.name,
   );
 }
+
+export { setup };


### PR DESCRIPTION
change device controller to not expect setup to be default export In order to allow devices to export other functions.

SES code can't export both using a named list and a default. The device controller was insisting on default in the non-SES case, and a named list (using require) in the SES case. 

This change makes it use a named-list in both cases, and converts all the test vats to comply with that. 

This breaks compatibility, and we'll have to make other changes to dependent code if we accept it.