### PR TITLE
tolerate vats/devices with non-default exports

### DIFF
--- a/src/build-source-bundle.js
+++ b/src/build-source-bundle.js
@@ -11,6 +11,7 @@ export default async function bundleSource(startFilename) {
     acornInjectPlugins: [infixBang()],
   });
   const { output } = await bundle.generate({
+    exports: 'named',
     format: 'cjs',
   });
   if (output.length !== 1) {

--- a/src/controller.js
+++ b/src/controller.js
@@ -109,7 +109,7 @@ function buildSESKernel(initialState) {
   });
   const kernelSource = getKernelSource();
   // console.log('building kernel');
-  const buildKernel = s.evaluate(kernelSource, { require: r })();
+  const buildKernel = s.evaluate(kernelSource, { require: r })().default;
   const kernelEndowments = { setImmediate };
   const kernel = buildKernel(kernelEndowments, initialState);
   return { kernel, s, r };
@@ -158,7 +158,7 @@ export async function buildVatController(config, withSES = true, argv = []) {
       // const r = s.makeRequire({ '@agoric/harden': true, '@agoric/nat': Nat });
       let source = await bundleSource(`${sourceIndex}`);
       source = `(${source})`;
-      setup = s.evaluate(source, { require: r })();
+      setup = s.evaluate(source, { require: r })().default;
     } else {
       // eslint-disable-next-line global-require,import/no-dynamic-require
       setup = require(`${sourceIndex}`).default;
@@ -177,7 +177,7 @@ export async function buildVatController(config, withSES = true, argv = []) {
     if (withSES) {
       let source = await bundleSource(`${sourceIndex}`);
       source = `(${source})`;
-      setup = s.evaluate(source, { require: r })();
+      setup = s.evaluate(source, { require: r })().default;
     } else {
       // eslint-disable-next-line global-require,import/no-dynamic-require
       setup = require(`${sourceIndex}`).default;


### PR DESCRIPTION
We define vats (and devices) as a source file which contains a default export
named `setup()` which accepts a syscall function and returns a dispatch
function. But it would be nice to allow additional exports, so unit tests can
exercise subsets of the functionality.

This was difficult because our use of 'rollup' produced varying export names.
If the vat/device module had only a default export (e.g. `export default
function setup(){}`), the return value of rollup `R` would be exactly that
function: `dispatch = R(syscall)`. But if the module also had non-default
exports (e.g. `export default function setup(){}` and `export function
other(){}`), the return value would be an object with both `.default` and
`.other` properties, so `dispatch = R.default(syscall)`.

This patch changes the options we give to rollup, so that the default export
gets placed on a property named `.default` in both cases. It also modifies
the three places where we use rollup to expect `R.default` instead of just
`R`:

* loading the kernel in a SES realm
* loading a genesis vat in a SES realm
* loading a genesis device in a SES realm

Note that `esm` returns an object with `R.default` and `R.other` in both
cases. We use esm to run unit tests and the top-level `bin/vat` tool, but
most everything else ends up using rollup.