### PR TITLE
upgrade to SES v0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1948,9 +1948,9 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "ses": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ses/-/ses-0.6.0.tgz",
-      "integrity": "sha512-z705lHPqOZCBE0tYdKhVhnQEGC/KWTSI4DE2KD+0bMtCtu2MNMvfxO7wPl+TrRCN/xvzH/YEH5Z+tzu4rdoFyg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ses/-/ses-0.6.1.tgz",
+      "integrity": "sha512-yD2vsc/V5pqWM39Fo1wzgrPThIMzaP/ZcCIl4G3xKrDUjY0YrBmxNIYEsa2NbbRLwrmXE9aqaVYouSi9Vt91xg==",
       "requires": {
         "@agoric/make-hardener": "^0.0.6",
         "esm": "^3.2.25"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rollup": "^1.19.3",
     "rollup-plugin-node-resolve": "^5.2.0",
     "semver": "^6.3.0",
-    "ses": "^0.6.0",
+    "ses": "^0.6.1",
     "yargs": "^13.3.0"
   },
   "files": [


### PR DESCRIPTION
This fixes a sandbox escape in the realms-shim, described in
https://github.com/Agoric/realms-shim/issues/48