### PR TITLE
Use (mostly numeric) vatID/deviceID everywhere within kernel

### DIFF
--- a/src/kernel/id.js
+++ b/src/kernel/id.js
@@ -1,0 +1,67 @@
+import harden from '@agoric/harden';
+import Nat from '@agoric/nat';
+
+// Vats are identified by an integer index, which (for typechecking purposes)
+// is encoded as `vNN`. Devices are similarly identified as `dNN`. Both have
+// human-readable names, which are provided to controller.addGenesisVat(),
+// and usually come from the `vat-NAME.js` filenames processed in
+// loadBasedir(). These names also appear in the `vats` and `devices`
+// arguments to the bootstrap Vat's `bootstrap()` function, and in debug
+// messages.
+
+export function insistVatID(s) {
+  try {
+    if (s !== `${s}`) {
+      throw new Error(`not a string`);
+    }
+    s = `${s}`;
+    if (!s.startsWith(`v`)) {
+      throw new Error(`does not start with 'v'`);
+    }
+    Nat(Number(s.slice(1)));
+  } catch (e) {
+    throw new Error(`'${s} is not a 'vNN'-style VatID: ${e.message}`);
+  }
+}
+
+export function makeVatID(index) {
+  return `v${Nat(index)}`;
+}
+
+export function insistDeviceID(s) {
+  try {
+    if (s !== `${s}`) {
+      throw new Error(`not a string`);
+    }
+    s = `${s}`;
+    if (!s.startsWith(`d`)) {
+      throw new Error(`does not start with 'd'`);
+    }
+    Nat(Number(s.slice(1)));
+  } catch (e) {
+    throw new Error(`'${s} is not a 'dNN'-style DeviceID: ${e.message}`);
+  }
+}
+
+export function makeDeviceID(index) {
+  return `d${Nat(index)}`;
+}
+
+export function parseVatOrDeviceID(s) {
+  if (s !== `${s}`) {
+    throw new Error(`${s} is not a string, so cannot be a VatID/DevieID`);
+  }
+  s = `${s}`;
+  let type;
+  let idSuffix;
+  if (s.startsWith('v')) {
+    type = 'vat';
+    idSuffix = s.slice(1);
+  } else if (s.startsWith('v')) {
+    type = 'device';
+    idSuffix = s.slice(1);
+  } else {
+    throw new Error(`'${s}' is neither a VatID nor a DeviceID`);
+  }
+  return harden({ type, id: Nat(Number(idSuffix)) });
+}

--- a/src/kernel/state/vatKeeper.js
+++ b/src/kernel/state/vatKeeper.js
@@ -2,25 +2,23 @@ import harden from '@agoric/harden';
 import { insist } from '../../insist';
 import { parseKernelSlot } from '../parseKernelSlots';
 import { makeVatSlot, parseVatSlot } from '../../parseVatSlots';
+import { insistVatID } from '../id';
 
 // makeVatKeeper is a pure function: all state is kept in the argument object
 
-export default function makeVatKeeper(
-  state,
-  vatID,
-  addKernelObject,
-  addKernelPromise,
-) {
-  function createStartingVatState() {
-    state.kernelSlotToVatSlot = {}; // kpNN -> p+NN, etc
-    state.vatSlotToKernelSlot = {}; // p+NN -> kpNN, etc
+export function initializeVatState(vatID, state) {
+  state.kernelSlotToVatSlot = {}; // kpNN -> p+NN, etc
+  state.vatSlotToKernelSlot = {}; // p+NN -> kpNN, etc
 
-    state.nextObjectID = 50;
-    state.nextPromiseID = 60;
-    state.nextDeviceID = 70;
+  state.nextObjectID = 50;
+  state.nextPromiseID = 60;
+  state.nextDeviceID = 70;
 
-    state.transcript = [];
-  }
+  state.transcript = [];
+}
+
+export function makeVatKeeper(state, vatID, addKernelObject, addKernelPromise) {
+  insistVatID(vatID);
 
   function insistVatSlotType(type, slot) {
     insist(
@@ -107,7 +105,6 @@ export default function makeVatKeeper(
   }
 
   return harden({
-    createStartingVatState,
     mapVatSlotToKernelSlot,
     mapKernelSlotToVatSlot,
     getTranscript,

--- a/test/test-devices.js
+++ b/test/test-devices.js
@@ -60,7 +60,7 @@ async function test1(t, withSES) {
   };
   const c = await buildVatController(config, withSES);
   await c.step();
-  c.queueToExport('_bootstrap', 'o+0', 'step1', capargs([]));
+  c.queueToVatExport('_bootstrap', 'o+0', 'step1', capargs([]));
   await c.step();
   console.log(c.dump().log);
   t.deepEqual(c.dump().log, [
@@ -191,10 +191,11 @@ async function testState(t, withSES) {
   // The initial state should be missing (null). Then we set it with the call
   // from bootstrap, and read it back.
   const c1 = await buildVatController(config, withSES, ['write+read']);
+  const d3 = c1.deviceNameToID('d3');
   await c1.run();
   t.deepEqual(c1.dump().log, ['undefined', 'w+r', 'called', 'got {"s":"new"}']);
-  t.deepEqual(JSON.parse(c1.getState()).devices.d3.deviceState, { s: 'new' });
-  t.deepEqual(JSON.parse(c1.getState()).devices.d3.nextObjectID, 10);
+  t.deepEqual(JSON.parse(c1.getState()).devices[d3].deviceState, { s: 'new' });
+  t.deepEqual(JSON.parse(c1.getState()).devices[d3].nextObjectID, 10);
 
   t.end();
 }

--- a/test/test-liveslots.js
+++ b/test/test-liveslots.js
@@ -46,12 +46,15 @@ test('calls', async t => {
   kernel.addGenesisVat('vat', setup);
 
   await kernel.start('bootstrap', `[]`);
+  const bootstrapVatID = kernel.vatNameToID('bootstrap');
+  const vatID = kernel.vatNameToID('vat');
+
   // cycle past the bootstrap() call
   await kernel.step();
   log.shift();
   t.deepEqual(kernel.dump().runQueue, []);
 
-  const root = kernel.addImport('bootstrap', kernel.addExport('vat', 'o+0'));
+  const root = kernel.addImport(bootstrapVatID, kernel.addExport(vatID, 'o+0'));
 
   // root!one() // sendOnly
   syscall.send(root, 'one', capargs(['args']), undefined);
@@ -127,9 +130,12 @@ test('liveslots pipelines to syscall.send', async t => {
   kernel.addGenesisVat('b', setupB);
 
   await kernel.start(); // no bootstrap
+  const a = kernel.vatNameToID('a');
+  const b = kernel.vatNameToID('b');
+
   t.deepEqual(kernel.dump().runQueue, []);
 
-  const root = kernel.addImport('b', kernel.addExport('a', 'o+0'));
+  const root = kernel.addImport(b, kernel.addExport(a, 'o+0'));
 
   // root!one(x) // sendOnly
   syscall.send(


### PR DESCRIPTION
.. as the index for kernel state data structures, instead of user-provided
vatName/deviceName strings. This will make it easier to use key/value state
storage (#144), since the keys will be more uniform (and shorter, and not
vulnerable to people using the separator string in their vat name). They look
like "vNN" and "dNN", where NN is a positive integer.

This will also make adding dynamic Vats easier (#19), as we'll just increment
a counter instead of asking the user to invent a unique name.

closes #146