### PR TITLE
liveSlots.js: makeQueued allow property lookup

### DIFF
--- a/demo/encouragementBotCommsWavyDot/vat-bot.js
+++ b/demo/encouragementBotCommsWavyDot/vat-bot.js
@@ -11,9 +11,12 @@ export default function setup(syscall, state, helpers) {
     state,
     _E =>
       harden({
-        encourageMe(name) {
-          log(`=> encouragementBot.encourageMe got the name: ${name}`);
-          return `${name}, you are awesome, keep it up!`;
+        encourageMe(nameObj) {
+          // Test of tildot property get.
+          return nameObj~.name.then(name => {
+            log(`=> encouragementBot.encourageMe got the name: ${name}`);
+            return `${name}, you are awesome, keep it up!`;
+          });
         },
       }),
     helpers.vatID,

--- a/demo/encouragementBotCommsWavyDot/vat-user.js
+++ b/demo/encouragementBotCommsWavyDot/vat-user.js
@@ -13,7 +13,7 @@ export default function setup(syscall, state, helpers) {
         talkToBot(pbot, botName) {
           log(`=> user.talkToBot is called with ${botName}`);
           pbot
-            ~.encourageMe('user')
+            ~.encourageMe({ name: 'user' })
             .then(myEncouragement =>
               log(`=> user receives the encouragement: ${myEncouragement}`),
             );

--- a/src/kernel/liveSlots.js
+++ b/src/kernel/liveSlots.js
@@ -22,12 +22,13 @@ function build(syscall, _state, makeRoot, forVatID) {
   function makeQueued(slot) {
     /* eslint-disable no-use-before-define */
     const handler = {
-      GET(_o, prop) {
-        // Support: o![prop]!(...args)
-        return (...args) => queueMessage(slot, prop, args);
+      GET(target, prop) {
+        // Support: o~.[prop] remote property lookup
+        // FIXME: Do not stall the pipeline!
+        return target.then(o => o[prop]);
       },
       POST(_o, prop, args) {
-        // Support: o![prop](...args).
+        // Support: o~.[prop](...args) remote method invocation
         return queueMessage(slot, prop, args);
       },
     };


### PR DESCRIPTION
This is the smallest possible change to support remote property lookup (via a round-trip).

Fixes https://github.com/Agoric/cosmic-swingset/issues/83

For completeness, support for property lookup should be plumbed into the pipelining architecture so that we can do something like:

```js
obj~.prop1~.prop2~.method(args)~.prop3~.method2(args2)
```

and have the whole thing be pipelined.
