### PR TITLE
Move E() implementation to `@agoric/eventual-send`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,30 +18,66 @@
       "integrity": "sha512-2yhcfAeGiRLv0OmstYa2hUDPWKE7THCwEjZXi3WeNAz2B6ExeAVkBFDVxbmK3DDR2o47Gwcbj/8oABcH+Q0P0Q=="
     },
     "@agoric/default-evaluate-options": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.2.1.tgz",
-      "integrity": "sha512-fjRrkHnGzTSaquIBjHNjAq2W4xfnuTX8iL6l8+I1jYsGlWRRDrawREN9jF731+Z0iY0PTaKzuYo0bpjS0FB8XA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.2.3.tgz",
+      "integrity": "sha512-rqDmuQblQ1y+6rrbyf31697iuxArkYc+9g08X5fE84ULs96WiC0Vjq8Z1XfPZocfKnf2qtN2E1xxM22jgVeOFA==",
       "requires": {
         "@agoric/babel-parser": "^7.6.2",
-        "@agoric/eventual-send": "^0.3.0",
+        "@agoric/eventual-send": "^0.3.2",
         "@agoric/transform-eventual-send": "^1.0.0",
         "@babel/generator": "^7.5.5",
         "esm": "^3.2.5"
+      },
+      "dependencies": {
+        "@agoric/eventual-send": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.2.tgz",
+          "integrity": "sha512-ZFn9s3KN9++LTbYTjQlHM9BtIuoMm1x5kh50xcTUbHcr4gkRKw/SEL5/3QSOF3K8bj2elIMHy7j8ij1ltsTGlQ==",
+          "requires": {
+            "@agoric/harden": "^0.0.4"
+          }
+        }
       }
     },
     "@agoric/evaluate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@agoric/evaluate/-/evaluate-2.0.0.tgz",
-      "integrity": "sha512-AWq5FsAgDJpw6/NbOgH5XNgK4LJsIEstbDDL9mcYQ6ULYSNie0Pla+QnvlDqF1+m0A1uOg5/su+hdnywRO/7ug==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@agoric/evaluate/-/evaluate-2.1.0.tgz",
+      "integrity": "sha512-vm4Ca+3H8miCKoINoxujWDo5LJnbS/Qaa+A7/B2Y7ihbuLF62+H4pJvZ47LfzZpRg4/azV2ClMEQlUUXf6mzQA==",
       "requires": {
-        "@agoric/default-evaluate-options": "^0.2.1",
+        "@agoric/default-evaluate-options": "^0.2.3",
         "esm": "^3.2.5"
+      },
+      "dependencies": {
+        "@agoric/default-evaluate-options": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.2.3.tgz",
+          "integrity": "sha512-rqDmuQblQ1y+6rrbyf31697iuxArkYc+9g08X5fE84ULs96WiC0Vjq8Z1XfPZocfKnf2qtN2E1xxM22jgVeOFA==",
+          "requires": {
+            "@agoric/babel-parser": "^7.6.2",
+            "@agoric/eventual-send": "^0.3.2",
+            "@agoric/transform-eventual-send": "^1.0.0",
+            "@babel/generator": "^7.5.5",
+            "esm": "^3.2.5"
+          }
+        },
+        "@agoric/eventual-send": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.2.tgz",
+          "integrity": "sha512-ZFn9s3KN9++LTbYTjQlHM9BtIuoMm1x5kh50xcTUbHcr4gkRKw/SEL5/3QSOF3K8bj2elIMHy7j8ij1ltsTGlQ==",
+          "requires": {
+            "@agoric/harden": "^0.0.4"
+          }
+        }
       }
     },
     "@agoric/eventual-send": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.0.tgz",
-      "integrity": "sha512-PU6yGwyeicCf7oFzjeH34b1aFed95HEO2xheI5EjUlWzlo6/QnH9Hbt4/NxQ5XvrzpD4JszOs0LYG7nTIjiQow=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.2.tgz",
+      "integrity": "sha512-ZFn9s3KN9++LTbYTjQlHM9BtIuoMm1x5kh50xcTUbHcr4gkRKw/SEL5/3QSOF3K8bj2elIMHy7j8ij1ltsTGlQ==",
+      "dev": true,
+      "requires": {
+        "@agoric/harden": "^0.0.4"
+      }
     },
     "@agoric/harden": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lint-check": "eslint '**/*.{js,jsx}'"
   },
   "devDependencies": {
-    "@agoric/eventual-send": "^0.3.2",
     "eslint": "^6.4.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.3.0",
@@ -41,6 +40,7 @@
     "@agoric/acorn-eventual-send": "^1.0.1",
     "@agoric/default-evaluate-options": "^0.2.3",
     "@agoric/evaluate": "^2.1.0",
+    "@agoric/eventual-send": "^0.3.2",
     "@agoric/harden": "^0.0.4",
     "@agoric/marshal": "^0.1.0",
     "@agoric/nat": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint-check": "eslint '**/*.{js,jsx}'"
   },
   "devDependencies": {
-    "@agoric/eventual-send": "^0.3.0",
+    "@agoric/eventual-send": "^0.3.2",
     "eslint": "^6.4.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.3.0",
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@agoric/acorn-eventual-send": "^1.0.1",
-    "@agoric/default-evaluate-options": "^0.2.1",
-    "@agoric/evaluate": "^2.0.0",
+    "@agoric/default-evaluate-options": "^0.2.3",
+    "@agoric/evaluate": "^2.1.0",
     "@agoric/harden": "^0.0.4",
     "@agoric/marshal": "^0.1.0",
     "@agoric/nat": "^2.0.0",

--- a/src/controller.js
+++ b/src/controller.js
@@ -17,6 +17,7 @@ import { insistCapData } from './capdata';
 import { parseVatSlot } from './parseVatSlots';
 
 const evaluateOptions = makeDefaultEvaluateOptions();
+evaluateOptions.shims.unshift('this.globalThis = this');
 
 export function loadBasedir(basedir) {
   console.log(`= loading config from basedir ${basedir}`);

--- a/src/controller.js
+++ b/src/controller.js
@@ -17,6 +17,8 @@ import { insistCapData } from './capdata';
 import { parseVatSlot } from './parseVatSlots';
 
 const evaluateOptions = makeDefaultEvaluateOptions();
+// globalThis is standard, we want it to be frozen
+// as one of our root realm's global properties.
 evaluateOptions.shims.unshift('this.globalThis = this');
 
 export function loadBasedir(basedir) {

--- a/src/kernel/liveSlots.js
+++ b/src/kernel/liveSlots.js
@@ -1,5 +1,6 @@
 import harden from '@agoric/harden';
 import Nat from '@agoric/nat';
+import { E } from '@agoric/eventual-send';
 import { QCLASS, mustPassByPresence, makeMarshal } from '@agoric/marshal';
 import { insist } from '../insist';
 import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots';
@@ -207,82 +208,6 @@ function build(syscall, _state, makeRoot, forVatID) {
 
     return done.p;
   }
-
-  /**
-   * A Proxy handler for E(x).
-   *
-   * @param {Promise} ep Promise with eventual send API
-   * @returns {ProxyHandler} the Proxy handler
-   */
-  function EPromiseHandler(ep) {
-    return {
-      get(_target, p, _receiver) {
-        if (`${p}` !== p) {
-          return undefined;
-        }
-        // Harden this Promise because it's our only opportunity to ensure
-        // p1=E(x).foo() is hardened. The Handled Promise API does not (yet)
-        // allow the handler to synchronously influence the promise returned
-        // by the handled methods, so we must freeze it from the outside. See
-        // #95 for details.
-        return (...args) => harden(ep.post(p, args));
-      },
-      deleteProperty(_target, p) {
-        return harden(ep.delete(p));
-      },
-      set(_target, p, value, _receiver) {
-        return harden(ep.put(p, value));
-      },
-      apply(_target, _thisArg, argArray = []) {
-        return harden(ep.post(undefined, argArray));
-      },
-      has(_target, _p) {
-        // We just pretend everything exists.
-        return true;
-      },
-    };
-  }
-
-  function E(x) {
-    // p = E(x).name(args)
-    //
-    // E(x) returns a proxy on which you can call arbitrary methods. Each of
-    // these method calls returns a promise. The method will be invoked on
-    // whatever 'x' designates (or resolves to) in a future turn, not this
-    // one. 'x' might be/resolve-to:
-    //
-    // * a local object: do x[name](args) in a future turn
-    // * a normal Promise: wait for x to resolve, then x[name](args)
-    // * a Presence: send message to remote Vat to do x[name](args)
-    // * a Promise that we returned earlier: send message to whichever Vat
-    //   gets to decide what the Promise resolves to
-
-    if (outstandingProxies.has(x)) {
-      throw Error('E(E(x)) is invalid, you probably want E(E(x).foo()).bar()');
-    }
-
-    const slot = valToSlot.get(x);
-
-    if (slot && parseVatSlot(slot).type === 'device') {
-      throw new Error(`E() does not accept device nodes`);
-    }
-
-    lsdebug(` treating as promise`);
-    const targetP = Promise.resolve(x);
-
-    // targetP might resolve to a Presence
-    const handler = EPromiseHandler(targetP);
-
-    const p = harden(new Proxy({}, handler));
-    outstandingProxies.add(p);
-    return p;
-  }
-  // Like Promise.resolve, except that if applied to a presence, it
-  // would be better for it to return the remote promise for this
-  // specimen, rather than a fresh local promise fulfilled by this
-  // specimen.
-  // TODO: for now, just alias Promise.resolve.
-  E.resolve = specimen => Promise.resolve(specimen);
 
   function DeviceHandler(slot) {
     return {

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -3,7 +3,7 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
 import { makeMarshal, mustPassByPresence } from '@agoric/marshal';
-import '@agoric/eventual-send';
+import '@agoric/eventual-send'; // for side-effect: ensure HandledPromise is installed
 
 import { makeMarshaller } from '../src/kernel/liveSlots';
 import makePromise from '../src/makePromise';

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -3,7 +3,7 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
 import { makeMarshal, mustPassByPresence } from '@agoric/marshal';
-import { maybeExtendPromise } from '@agoric/eventual-send';
+import '@agoric/eventual-send';
 
 import { makeMarshaller } from '../src/kernel/liveSlots';
 import makePromise from '../src/makePromise';
@@ -19,8 +19,6 @@ export default function runTests() {
     const controller = await buildVatController(config, false);
     await controller.run();
   }
-
-  maybeExtendPromise(Promise);
 
   test('serialize static data', t => {
     const m = makeMarshal();


### PR DESCRIPTION
This change should now be ready to land with `@agoric/eventual-send@0.3.2` and the rebuilt `@agoric/default-evaluate-options` and `@agoric/evaluate`.

Closes https://github.com/Agoric/SwingSet/issues/106
Closes Agoric/eventual-send#30