### PR TITLE
deps: upgrade to working eventual-send

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,65 +18,30 @@
       "integrity": "sha512-2yhcfAeGiRLv0OmstYa2hUDPWKE7THCwEjZXi3WeNAz2B6ExeAVkBFDVxbmK3DDR2o47Gwcbj/8oABcH+Q0P0Q=="
     },
     "@agoric/default-evaluate-options": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.2.3.tgz",
-      "integrity": "sha512-rqDmuQblQ1y+6rrbyf31697iuxArkYc+9g08X5fE84ULs96WiC0Vjq8Z1XfPZocfKnf2qtN2E1xxM22jgVeOFA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.2.4.tgz",
+      "integrity": "sha512-fyP4ToTZhlzH7AfFAXQfQGmiR/DsjO10N6gOxND2SmK2Ck5rcsCeFLDYwfNiuq6u2g3vVpEzhExKXVlF32+V8g==",
       "requires": {
         "@agoric/babel-parser": "^7.6.2",
-        "@agoric/eventual-send": "^0.3.2",
+        "@agoric/eventual-send": "^0.3.3",
         "@agoric/transform-eventual-send": "^1.0.0",
         "@babel/generator": "^7.5.5",
         "esm": "^3.2.5"
-      },
-      "dependencies": {
-        "@agoric/eventual-send": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.2.tgz",
-          "integrity": "sha512-ZFn9s3KN9++LTbYTjQlHM9BtIuoMm1x5kh50xcTUbHcr4gkRKw/SEL5/3QSOF3K8bj2elIMHy7j8ij1ltsTGlQ==",
-          "requires": {
-            "@agoric/harden": "^0.0.4"
-          }
-        }
       }
     },
     "@agoric/evaluate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@agoric/evaluate/-/evaluate-2.1.0.tgz",
-      "integrity": "sha512-vm4Ca+3H8miCKoINoxujWDo5LJnbS/Qaa+A7/B2Y7ihbuLF62+H4pJvZ47LfzZpRg4/azV2ClMEQlUUXf6mzQA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@agoric/evaluate/-/evaluate-2.1.1.tgz",
+      "integrity": "sha512-rpFOOeWwe4G3DQbuyKO9s2UmHrv6XtB3eZuT8pAIMLdmny4ADPgwvP4iCviciljP/7vlaOX2TkpMI8sDDmW6zw==",
       "requires": {
-        "@agoric/default-evaluate-options": "^0.2.3",
+        "@agoric/default-evaluate-options": "^0.2.4",
         "esm": "^3.2.5"
-      },
-      "dependencies": {
-        "@agoric/default-evaluate-options": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.2.3.tgz",
-          "integrity": "sha512-rqDmuQblQ1y+6rrbyf31697iuxArkYc+9g08X5fE84ULs96WiC0Vjq8Z1XfPZocfKnf2qtN2E1xxM22jgVeOFA==",
-          "requires": {
-            "@agoric/babel-parser": "^7.6.2",
-            "@agoric/eventual-send": "^0.3.2",
-            "@agoric/transform-eventual-send": "^1.0.0",
-            "@babel/generator": "^7.5.5",
-            "esm": "^3.2.5"
-          }
-        },
-        "@agoric/eventual-send": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.2.tgz",
-          "integrity": "sha512-ZFn9s3KN9++LTbYTjQlHM9BtIuoMm1x5kh50xcTUbHcr4gkRKw/SEL5/3QSOF3K8bj2elIMHy7j8ij1ltsTGlQ==",
-          "requires": {
-            "@agoric/harden": "^0.0.4"
-          }
-        }
       }
     },
     "@agoric/eventual-send": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.2.tgz",
-      "integrity": "sha512-ZFn9s3KN9++LTbYTjQlHM9BtIuoMm1x5kh50xcTUbHcr4gkRKw/SEL5/3QSOF3K8bj2elIMHy7j8ij1ltsTGlQ==",
-      "requires": {
-        "@agoric/harden": "^0.0.4"
-      }
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.3.3.tgz",
+      "integrity": "sha512-Iijtb3L4wadVrQUXJwEjnvwJim6pbn72LXOXNezfILDuXhtmVwcX006EoGjb0PO0lMWia9KFNh2Oik1/5Bydyw=="
     },
     "@agoric/harden": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   },
   "dependencies": {
     "@agoric/acorn-eventual-send": "^1.0.1",
-    "@agoric/default-evaluate-options": "^0.2.3",
-    "@agoric/evaluate": "^2.1.0",
-    "@agoric/eventual-send": "^0.3.2",
+    "@agoric/default-evaluate-options": "^0.2.4",
+    "@agoric/evaluate": "^2.1.1",
+    "@agoric/eventual-send": "^0.3.3",
     "@agoric/harden": "^0.0.4",
     "@agoric/marshal": "^0.1.1",
     "@agoric/nat": "^2.0.0",


### PR DESCRIPTION
The prior eventual-send had a problem with the "override mistake" under SES.

Notably, the `HandledPromise` when it is a constructor, cannot also have a static `apply()` method, since that conflicts with `Function.prototype.apply`.

Working around this by not yet making it a constructor.
